### PR TITLE
fix: enable more linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,6 @@ linters:
     - cyclop # we have gocyclo, apparently its better
     - execinquery # deprecated
 
-    # - bodyclose # we want this
     - contextcheck # we want this
     - copyloopvar # if we update to later than go 1.22
     - depguard # for banning specific dependencies
@@ -38,7 +37,7 @@ linters:
     - funlen # we want this
     - goconst # we want this
     - gocritic # we want this
-    - gosec # we want this
+    # - gosec # we want this
     - intrange # later version of go
     - ireturn # we want this
     - lll # we want this

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,6 @@ linters:
     - funlen # we want this
     - goconst # we want this
     - gocritic # we want this
-    # - gosec # we want this
     - intrange # later version of go
     - ireturn # we want this
     - lll # we want this
@@ -47,7 +46,7 @@ linters:
     - noctx # we want this
     - nestif # we want this
     - revive # we want this
-    - stylecheck # we want this
+    # - stylecheck # we want this
     - tagliatelle # we want this
     - testifylint # we want this
     - thelper # we want this
@@ -89,6 +88,10 @@ issues:
         - goerr113
         - dupl
       path: _test\.go
+
+    - linters:
+        - stylecheck
+      path: pkg/config-api-client
 
     - linters:
         - dupl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,6 @@ linters:
     - cyclop # we have gocyclo, apparently its better
     - execinquery # deprecated
 
-    - canonicalheader # for checking copyright headers
     - bodyclose # we want this
     - contextcheck # we want this
     - copyloopvar # if we update to later than go 1.22
@@ -46,7 +45,6 @@ linters:
     - maintidx # we want this
     - mnd # we want this  todo: also see gomnd
     - gomnd # disabled in gl provider  todo: also see mnd
-    # - nlreturn # we want this
     - noctx # we want this
     - nestif # we want this
     - revive # we want this

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,7 +38,7 @@ linters:
     - goconst # we want this
     - gocritic # we want this
     - intrange # later version of go
-    - ireturn # we want this
+    # - ireturn # we want this
     - lll # we want this
     - maintidx # we want this
     - mnd # we want this  todo: also see gomnd
@@ -107,5 +107,13 @@ issues:
     - linters:
         - stylecheck
       text: "ST1005:"
+
+    - linters:
+        - ireturn
+      path: internal/provider/resources
+
+    - linters:
+        - ireturn
+      path: internal/provider/util/retry.go
 
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,7 @@ linters:
     - cyclop # we have gocyclo, apparently its better
     - execinquery # deprecated
 
-    - bodyclose # we want this
+    # - bodyclose # we want this
     - contextcheck # we want this
     - copyloopvar # if we update to later than go 1.22
     - depguard # for banning specific dependencies

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,6 @@ linters:
     - noctx # we want this
     - nestif # we want this
     - revive # we want this
-    # - stylecheck # we want this
     - tagliatelle # we want this
     - testifylint # we want this
     - thelper # we want this

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,7 @@ linters:
     - maintidx # we want this
     - mnd # we want this  todo: also see gomnd
     - gomnd # disabled in gl provider  todo: also see mnd
-    - nlreturn # we want this
+    # - nlreturn # we want this
     - noctx # we want this
     - nestif # we want this
     - revive # we want this

--- a/internal/provider/config/config.go
+++ b/internal/provider/config/config.go
@@ -23,6 +23,7 @@ func getEnv(key, fallback string) string {
 	if value == "" {
 		return fallback
 	}
+
 	return value
 }
 

--- a/internal/provider/config/config.go
+++ b/internal/provider/config/config.go
@@ -8,7 +8,7 @@ import "os"
 
 const (
 	MaxRetriesForTooManyRequests = 10
-	TokenURL                     = "https://sso.common.cloud.hpe.com/as/token.oauth2"
+	TokenURL                     = "https://sso.common.cloud.hpe.com/as/token.oauth2" // #nosec G101
 	UXIDefaultHost               = "api.capenetworks.com"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -135,7 +135,7 @@ func (p *uxiConfigurationProvider) Configure(
 	uxiConfiguration := config_api_client.NewConfiguration()
 	uxiConfiguration.Host = configuration.Host
 	uxiConfiguration.Scheme = "https"
-	uxiConfiguration.HTTPClient = getHttpClient(clientID, clientSecret, configuration.TokenURL)
+	uxiConfiguration.HTTPClient = getHTTPClient(clientID, clientSecret, configuration.TokenURL)
 	uxiClient := config_api_client.NewAPIClient(uxiConfiguration)
 
 	resp.DataSourceData = uxiClient
@@ -172,7 +172,7 @@ func (p *uxiConfigurationProvider) Resources(_ context.Context) []func() resourc
 	}
 }
 
-func getHttpClient(clientID string, clientSecret string, tokenURL string) *http.Client {
+func getHTTPClient(clientID string, clientSecret string, tokenURL string) *http.Client {
 	config := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,

--- a/internal/provider/resources/data_source_agent.go
+++ b/internal/provider/resources/data_source_agent.go
@@ -122,9 +122,7 @@ func (d *agentDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")
 
 	if errorPresent {
@@ -132,6 +130,8 @@ func (d *agentDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(agentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_agent.go
+++ b/internal/provider/resources/data_source_agent.go
@@ -122,7 +122,7 @@ func (d *agentDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")

--- a/internal/provider/resources/data_source_agent.go
+++ b/internal/provider/resources/data_source_agent.go
@@ -122,7 +122,7 @@ func (d *agentDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")

--- a/internal/provider/resources/data_source_agent.go
+++ b/internal/provider/resources/data_source_agent.go
@@ -122,6 +122,7 @@ func (d *agentDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")

--- a/internal/provider/resources/data_source_agent.go
+++ b/internal/provider/resources/data_source_agent.go
@@ -128,12 +128,14 @@ func (d *agentDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(agentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -171,6 +173,7 @@ func (d *agentDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Agent. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_agent_group_assignment.go
+++ b/internal/provider/resources/data_source_agent_group_assignment.go
@@ -96,7 +96,7 @@ func (d *agentGroupAssignmentDataSource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")

--- a/internal/provider/resources/data_source_agent_group_assignment.go
+++ b/internal/provider/resources/data_source_agent_group_assignment.go
@@ -102,12 +102,14 @@ func (d *agentGroupAssignmentDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(agentGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -139,6 +141,7 @@ func (d *agentGroupAssignmentDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Agent Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_agent_group_assignment.go
+++ b/internal/provider/resources/data_source_agent_group_assignment.go
@@ -96,9 +96,7 @@ func (d *agentGroupAssignmentDataSource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")
 
 	if errorPresent {
@@ -106,6 +104,8 @@ func (d *agentGroupAssignmentDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(agentGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_agent_group_assignment.go
+++ b/internal/provider/resources/data_source_agent_group_assignment.go
@@ -96,7 +96,7 @@ func (d *agentGroupAssignmentDataSource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")

--- a/internal/provider/resources/data_source_agent_group_assignment.go
+++ b/internal/provider/resources/data_source_agent_group_assignment.go
@@ -96,6 +96,7 @@ func (d *agentGroupAssignmentDataSource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")

--- a/internal/provider/resources/data_source_group.go
+++ b/internal/provider/resources/data_source_group.go
@@ -102,6 +102,7 @@ func (d *groupDataSource) Read(
 		Id(*state.Filter.ID)
 
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_group")

--- a/internal/provider/resources/data_source_group.go
+++ b/internal/provider/resources/data_source_group.go
@@ -102,9 +102,7 @@ func (d *groupDataSource) Read(
 		Id(*state.Filter.ID)
 
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_group")
 
 	if errorPresent {
@@ -112,6 +110,8 @@ func (d *groupDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(groupResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_group.go
+++ b/internal/provider/resources/data_source_group.go
@@ -108,18 +108,21 @@ func (d *groupDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(groupResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
 	group := groupResponse.Items[0]
 	if util.IsRoot(group) {
 		resp.Diagnostics.AddError(errorSummary, "The root group cannot be used as a data source")
+
 		return
 	}
 
@@ -151,6 +154,7 @@ func (d *groupDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Group. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_group.go
+++ b/internal/provider/resources/data_source_group.go
@@ -102,7 +102,7 @@ func (d *groupDataSource) Read(
 		Id(*state.Filter.ID)
 
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_group")

--- a/internal/provider/resources/data_source_group.go
+++ b/internal/provider/resources/data_source_group.go
@@ -102,7 +102,7 @@ func (d *groupDataSource) Read(
 		Id(*state.Filter.ID)
 
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_group")

--- a/internal/provider/resources/data_source_network_group_assignment.go
+++ b/internal/provider/resources/data_source_network_group_assignment.go
@@ -96,7 +96,7 @@ func (d *networkGroupAssignmentDataSource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")

--- a/internal/provider/resources/data_source_network_group_assignment.go
+++ b/internal/provider/resources/data_source_network_group_assignment.go
@@ -96,7 +96,7 @@ func (d *networkGroupAssignmentDataSource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")

--- a/internal/provider/resources/data_source_network_group_assignment.go
+++ b/internal/provider/resources/data_source_network_group_assignment.go
@@ -96,9 +96,7 @@ func (d *networkGroupAssignmentDataSource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")
 
 	if errorPresent {
@@ -106,6 +104,8 @@ func (d *networkGroupAssignmentDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_network_group_assignment.go
+++ b/internal/provider/resources/data_source_network_group_assignment.go
@@ -96,6 +96,7 @@ func (d *networkGroupAssignmentDataSource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")

--- a/internal/provider/resources/data_source_network_group_assignment.go
+++ b/internal/provider/resources/data_source_network_group_assignment.go
@@ -102,12 +102,14 @@ func (d *networkGroupAssignmentDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -139,6 +141,7 @@ func (d *networkGroupAssignmentDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Network Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_sensor.go
+++ b/internal/provider/resources/data_source_sensor.go
@@ -143,12 +143,14 @@ func (d *sensorDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(sensorResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -189,6 +191,7 @@ func (d *sensorDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Sensor. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_sensor.go
+++ b/internal/provider/resources/data_source_sensor.go
@@ -137,9 +137,7 @@ func (d *sensorDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")
 
 	if errorPresent {
@@ -147,6 +145,8 @@ func (d *sensorDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(sensorResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_sensor.go
+++ b/internal/provider/resources/data_source_sensor.go
@@ -137,6 +137,7 @@ func (d *sensorDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")

--- a/internal/provider/resources/data_source_sensor.go
+++ b/internal/provider/resources/data_source_sensor.go
@@ -137,7 +137,7 @@ func (d *sensorDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")

--- a/internal/provider/resources/data_source_sensor.go
+++ b/internal/provider/resources/data_source_sensor.go
@@ -137,7 +137,7 @@ func (d *sensorDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")

--- a/internal/provider/resources/data_source_sensor_group_assignment.go
+++ b/internal/provider/resources/data_source_sensor_group_assignment.go
@@ -96,7 +96,7 @@ func (d *sensorGroupAssignmentDataSource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")

--- a/internal/provider/resources/data_source_sensor_group_assignment.go
+++ b/internal/provider/resources/data_source_sensor_group_assignment.go
@@ -96,6 +96,7 @@ func (d *sensorGroupAssignmentDataSource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")

--- a/internal/provider/resources/data_source_sensor_group_assignment.go
+++ b/internal/provider/resources/data_source_sensor_group_assignment.go
@@ -96,9 +96,7 @@ func (d *sensorGroupAssignmentDataSource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")
 
 	if errorPresent {
@@ -106,6 +104,8 @@ func (d *sensorGroupAssignmentDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(sensorGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_sensor_group_assignment.go
+++ b/internal/provider/resources/data_source_sensor_group_assignment.go
@@ -96,7 +96,7 @@ func (d *sensorGroupAssignmentDataSource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.Filter.ID)
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")

--- a/internal/provider/resources/data_source_sensor_group_assignment.go
+++ b/internal/provider/resources/data_source_sensor_group_assignment.go
@@ -102,12 +102,14 @@ func (d *sensorGroupAssignmentDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(sensorGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -139,6 +141,7 @@ func (d *sensorGroupAssignmentDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Sensor Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_service.go
+++ b/internal/provider/resources/data_source_service.go
@@ -121,12 +121,14 @@ func (d *serviceTestDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(serviceTestResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -162,6 +164,7 @@ func (d *serviceTestDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: ServiceTest. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_service.go
+++ b/internal/provider/resources/data_source_service.go
@@ -115,7 +115,7 @@ func (d *serviceTestDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	serviceTestResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/data_source_service.go
+++ b/internal/provider/resources/data_source_service.go
@@ -115,6 +115,7 @@ func (d *serviceTestDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	serviceTestResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/data_source_service.go
+++ b/internal/provider/resources/data_source_service.go
@@ -115,9 +115,7 @@ func (d *serviceTestDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	serviceTestResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")
 
 	if errorPresent {
@@ -125,6 +123,8 @@ func (d *serviceTestDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(serviceTestResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_service.go
+++ b/internal/provider/resources/data_source_service.go
@@ -115,7 +115,7 @@ func (d *serviceTestDataSource) Read(
 		Id(state.Filter.ID.ValueString())
 
 	serviceTestResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -98,7 +98,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -98,6 +98,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -98,7 +98,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -104,6 +104,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -110,6 +110,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 	if len(serviceTestGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -141,6 +142,7 @@ func (d *serviceTestGroupAssignmentDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: ServiceTest Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_service_test_group_assignment.go
+++ b/internal/provider/resources/data_source_service_test_group_assignment.go
@@ -98,9 +98,7 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")
 
 	if errorPresent {
@@ -108,6 +106,8 @@ func (d *serviceTestGroupAssignmentDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(serviceTestGroupAssignmentResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_wired_network.go
+++ b/internal/provider/resources/data_source_wired_network.go
@@ -126,7 +126,7 @@ func (d *wiredNetworkDataSource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/data_source_wired_network.go
+++ b/internal/provider/resources/data_source_wired_network.go
@@ -132,12 +132,14 @@ func (d *wiredNetworkDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -175,6 +177,7 @@ func (d *wiredNetworkDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Wired Network. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_wired_network.go
+++ b/internal/provider/resources/data_source_wired_network.go
@@ -126,9 +126,7 @@ func (d *wiredNetworkDataSource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")
 
 	if errorPresent {
@@ -136,6 +134,8 @@ func (d *wiredNetworkDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_wired_network.go
+++ b/internal/provider/resources/data_source_wired_network.go
@@ -126,7 +126,7 @@ func (d *wiredNetworkDataSource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/data_source_wired_network.go
+++ b/internal/provider/resources/data_source_wired_network.go
@@ -126,6 +126,7 @@ func (d *wiredNetworkDataSource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/data_source_wireless_network.go
+++ b/internal/provider/resources/data_source_wireless_network.go
@@ -136,7 +136,7 @@ func (d *wirelessNetworkDataSource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/data_source_wireless_network.go
+++ b/internal/provider/resources/data_source_wireless_network.go
@@ -136,7 +136,7 @@ func (d *wirelessNetworkDataSource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/data_source_wireless_network.go
+++ b/internal/provider/resources/data_source_wireless_network.go
@@ -136,9 +136,7 @@ func (d *wirelessNetworkDataSource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")
 
 	if errorPresent {
@@ -146,6 +144,8 @@ func (d *wirelessNetworkDataSource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")

--- a/internal/provider/resources/data_source_wireless_network.go
+++ b/internal/provider/resources/data_source_wireless_network.go
@@ -142,12 +142,14 @@ func (d *wirelessNetworkDataSource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkResponse.Items) != 1 {
 		resp.Diagnostics.AddError(errorSummary, "Could not find specified data source")
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -187,6 +189,7 @@ func (d *wirelessNetworkDataSource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Data Source type: Wireless Network. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 

--- a/internal/provider/resources/data_source_wireless_network.go
+++ b/internal/provider/resources/data_source_wireless_network.go
@@ -136,6 +136,7 @@ func (d *wirelessNetworkDataSource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.Filter.ID)
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/resource_agent.go
+++ b/internal/provider/resources/resource_agent.go
@@ -153,7 +153,7 @@ func (r *agentResource) Read(
 		AgentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")
@@ -219,7 +219,7 @@ func (r *agentResource) Update(
 		AgentsPatch(ctx, plan.ID.ValueString()).
 		AgentsPatchRequest(*patchRequest)
 	agent, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
@@ -262,7 +262,7 @@ func (r *agentResource) Delete(
 	request := r.client.ConfigurationAPI.AgentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_agent.go
+++ b/internal/provider/resources/resource_agent.go
@@ -153,7 +153,7 @@ func (r *agentResource) Read(
 		AgentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")
@@ -219,7 +219,7 @@ func (r *agentResource) Update(
 		AgentsPatch(ctx, plan.ID.ValueString()).
 		AgentsPatchRequest(*patchRequest)
 	agent, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
@@ -262,7 +262,7 @@ func (r *agentResource) Delete(
 	request := r.client.ConfigurationAPI.AgentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_agent.go
+++ b/internal/provider/resources/resource_agent.go
@@ -153,9 +153,7 @@ func (r *agentResource) Read(
 		AgentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")
 
 	if errorPresent {
@@ -163,6 +161,8 @@ func (r *agentResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(agentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -219,8 +219,6 @@ func (r *agentResource) Update(
 		AgentsPatch(ctx, plan.ID.ValueString()).
 		AgentsPatchRequest(*patchRequest)
 	agent, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
-
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -228,6 +226,8 @@ func (r *agentResource) Update(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(agent.Id)
 	plan.Name = types.StringValue(agent.Name)
@@ -262,9 +262,7 @@ func (r *agentResource) Delete(
 	request := r.client.ConfigurationAPI.AgentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -275,6 +273,8 @@ func (r *agentResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *agentResource) ImportState(

--- a/internal/provider/resources/resource_agent.go
+++ b/internal/provider/resources/resource_agent.go
@@ -153,6 +153,7 @@ func (r *agentResource) Read(
 		AgentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent")
@@ -218,6 +219,7 @@ func (r *agentResource) Update(
 		AgentsPatch(ctx, plan.ID.ValueString()).
 		AgentsPatchRequest(*patchRequest)
 	agent, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
@@ -260,6 +262,7 @@ func (r *agentResource) Delete(
 	request := r.client.ConfigurationAPI.AgentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_agent.go
+++ b/internal/provider/resources/resource_agent.go
@@ -116,6 +116,7 @@ func (r *agentResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Group. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -158,11 +159,13 @@ func (r *agentResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(agentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	agent := agentResponse.Items[0]
@@ -206,6 +209,7 @@ func (r *agentResource) Update(
 		pcapMode, err := config_api_client.NewPcapModeFromValue(*plannedPcapMode)
 		if err != nil {
 			resp.Diagnostics.AddError(errorSummary, err.Error())
+
 			return
 		}
 		patchRequest.PcapMode = pcapMode
@@ -219,6 +223,7 @@ func (r *agentResource) Update(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
@@ -260,9 +265,11 @@ func (r *agentResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("delete", "uxi_agent"), errorDetail)
+
 		return
 	}
 }

--- a/internal/provider/resources/resource_agent_group_assignment.go
+++ b/internal/provider/resources/resource_agent_group_assignment.go
@@ -128,9 +128,7 @@ func (r *agentGroupAssignmentResource) Create(
 		AgentGroupAssignmentsPost(ctx).
 		AgentGroupAssignmentsPostRequest(*postRequest)
 	agentGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("create", "uxi_agent_group_assignment"),
@@ -139,6 +137,8 @@ func (r *agentGroupAssignmentResource) Create(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(agentGroupAssignment.Id)
 	plan.GroupID = types.StringValue(agentGroupAssignment.Group.Id)
@@ -167,9 +167,7 @@ func (r *agentGroupAssignmentResource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")
 
 	if errorPresent {
@@ -177,6 +175,8 @@ func (r *agentGroupAssignmentResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(agentGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -225,9 +225,7 @@ func (r *agentGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		AgentGroupAssignmentDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -241,6 +239,8 @@ func (r *agentGroupAssignmentResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *agentGroupAssignmentResource) ImportState(

--- a/internal/provider/resources/resource_agent_group_assignment.go
+++ b/internal/provider/resources/resource_agent_group_assignment.go
@@ -101,6 +101,7 @@ func (r *agentGroupAssignmentResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Network Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -134,6 +135,7 @@ func (r *agentGroupAssignmentResource) Create(
 			util.GenerateErrorSummary("create", "uxi_agent_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 
@@ -170,11 +172,13 @@ func (r *agentGroupAssignmentResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(agentGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	agentGroupAssignment := agentGroupAssignmentResponse.Items[0]
@@ -224,12 +228,14 @@ func (r *agentGroupAssignmentResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("delete", "uxi_agent_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 }

--- a/internal/provider/resources/resource_agent_group_assignment.go
+++ b/internal/provider/resources/resource_agent_group_assignment.go
@@ -128,7 +128,7 @@ func (r *agentGroupAssignmentResource) Create(
 		AgentGroupAssignmentsPost(ctx).
 		AgentGroupAssignmentsPostRequest(*postRequest)
 	agentGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -167,7 +167,7 @@ func (r *agentGroupAssignmentResource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")
@@ -225,7 +225,7 @@ func (r *agentGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		AgentGroupAssignmentDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_agent_group_assignment.go
+++ b/internal/provider/resources/resource_agent_group_assignment.go
@@ -128,6 +128,7 @@ func (r *agentGroupAssignmentResource) Create(
 		AgentGroupAssignmentsPost(ctx).
 		AgentGroupAssignmentsPostRequest(*postRequest)
 	agentGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -166,6 +167,7 @@ func (r *agentGroupAssignmentResource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")
@@ -223,6 +225,7 @@ func (r *agentGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		AgentGroupAssignmentDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_agent_group_assignment.go
+++ b/internal/provider/resources/resource_agent_group_assignment.go
@@ -128,7 +128,7 @@ func (r *agentGroupAssignmentResource) Create(
 		AgentGroupAssignmentsPost(ctx).
 		AgentGroupAssignmentsPostRequest(*postRequest)
 	agentGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -167,7 +167,7 @@ func (r *agentGroupAssignmentResource) Read(
 		AgentGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	agentGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_agent_group_assignment")
@@ -225,7 +225,7 @@ func (r *agentGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		AgentGroupAssignmentDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -124,7 +124,7 @@ func (r *groupResource) Create(
 		GroupsPost(ctx).
 		GroupsPostRequest(*groupsPostRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -215,7 +215,7 @@ func (r *groupResource) Update(
 		GroupsPatch(ctx, plan.ID.ValueString()).
 		GroupsPatchRequest(*patchRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
@@ -255,7 +255,7 @@ func (r *groupResource) Delete(
 	request := r.client.ConfigurationAPI.GroupsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -284,7 +284,7 @@ func (r *groupResource) getGroup(
 ) (*config_api_client.GroupsGetItem, *string) {
 	request := r.client.ConfigurationAPI.GroupsGet(ctx).Id(id)
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -124,7 +124,7 @@ func (r *groupResource) Create(
 		GroupsPost(ctx).
 		GroupsPostRequest(*groupsPostRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -215,8 +215,7 @@ func (r *groupResource) Update(
 		GroupsPatch(ctx, plan.ID.ValueString()).
 		GroupsPatchRequest(*patchRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
-
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -255,7 +254,7 @@ func (r *groupResource) Delete(
 	request := r.client.ConfigurationAPI.GroupsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -284,6 +283,7 @@ func (r *groupResource) getGroup(
 ) (*config_api_client.GroupsGetItem, *string) {
 	request := r.client.ConfigurationAPI.GroupsGet(ctx).Id(id)
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	// this causes a segfault
 	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -116,13 +116,13 @@ func (r *groupResource) Create(
 		return
 	}
 
-	groups_post_request := config_api_client.NewGroupsPostRequest(plan.Name.ValueString())
+	groupsPostRequest := config_api_client.NewGroupsPostRequest(plan.Name.ValueString())
 	if !plan.ParentGroupID.IsUnknown() && !plan.ParentGroupID.IsNull() {
-		groups_post_request.SetParentId(plan.ParentGroupID.ValueString())
+		groupsPostRequest.SetParentId(plan.ParentGroupID.ValueString())
 	}
 	request := r.client.ConfigurationAPI.
 		GroupsPost(ctx).
-		GroupsPostRequest(*groups_post_request)
+		GroupsPostRequest(*groupsPostRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
 	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -125,14 +125,14 @@ func (r *groupResource) Create(
 		GroupsPost(ctx).
 		GroupsPostRequest(*groupsPostRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("create", "uxi_group"), errorDetail)
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(group.Id)
 	plan.Name = types.StringValue(group.Name)
@@ -216,14 +216,14 @@ func (r *groupResource) Update(
 		GroupsPatch(ctx, plan.ID.ValueString()).
 		GroupsPatchRequest(*patchRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("update", "uxi_group"), errorDetail)
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(group.Id)
 	plan.Name = types.StringValue(group.Name)
@@ -255,9 +255,7 @@ func (r *groupResource) Delete(
 	request := r.client.ConfigurationAPI.GroupsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -268,6 +266,8 @@ func (r *groupResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *groupResource) ImportState(
@@ -291,13 +291,13 @@ func (r *groupResource) getGroup(
 	if errorPresent {
 		return nil, errors.New(errorDetail)
 	}
-	defer response.Body.Close()
-
 	if len(groupResponse.Items) != 1 {
 		notFound := groupNotFoundError
 
 		return nil, errors.New(notFound)
 	}
+
+	defer response.Body.Close()
 
 	return &groupResponse.Items[0], nil
 }

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -97,6 +97,7 @@ func (r *groupResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Group. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -127,6 +128,7 @@ func (r *groupResource) Create(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("create", "uxi_group"), errorDetail)
+
 		return
 	}
 
@@ -164,14 +166,17 @@ func (r *groupResource) Read(
 	if errorDetail != nil {
 		if *errorDetail == groupNotFoundError {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(errorSummary, *errorDetail)
+
 		return
 	}
 
 	if util.IsRoot(*group) {
 		resp.Diagnostics.AddError(errorSummary, "The root group cannot be used as a resource")
+
 		return
 	}
 
@@ -214,6 +219,7 @@ func (r *groupResource) Update(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("update", "uxi_group"), errorDetail)
+
 		return
 	}
 
@@ -252,9 +258,11 @@ func (r *groupResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(util.GenerateErrorSummary("delete", "uxi_group"), errorDetail)
+
 		return
 	}
 }
@@ -281,6 +289,7 @@ func (r *groupResource) getGroup(
 
 	if len(groupResponse.Items) != 1 {
 		notFound := groupNotFoundError
+
 		return nil, &notFound
 	}
 

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -287,12 +287,11 @@ func (r *groupResource) getGroup(
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
 	// groupResponse, response, err := request.Execute()
 	// this causes a segfault
-	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		return nil, errors.New(errorDetail)
 	}
+	defer response.Body.Close()
 
 	if len(groupResponse.Items) != 1 {
 		notFound := groupNotFoundError

--- a/internal/provider/resources/resource_group.go
+++ b/internal/provider/resources/resource_group.go
@@ -124,6 +124,7 @@ func (r *groupResource) Create(
 		GroupsPost(ctx).
 		GroupsPostRequest(*groups_post_request)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -214,6 +215,7 @@ func (r *groupResource) Update(
 		GroupsPatch(ctx, plan.ID.ValueString()).
 		GroupsPatchRequest(*patchRequest)
 	group, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
@@ -253,6 +255,7 @@ func (r *groupResource) Delete(
 	request := r.client.ConfigurationAPI.GroupsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -281,6 +284,7 @@ func (r *groupResource) getGroup(
 ) (*config_api_client.GroupsGetItem, *string) {
 	request := r.client.ConfigurationAPI.GroupsGet(ctx).Id(id)
 	groupResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_network_group_assignment.go
+++ b/internal/provider/resources/resource_network_group_assignment.go
@@ -131,7 +131,7 @@ func (r *networkGroupAssignmentResource) Create(
 		NetworkGroupAssignmentsPost(ctx).
 		NetworkGroupAssignmentsPostRequest(*postRequest)
 	networkGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -170,7 +170,7 @@ func (r *networkGroupAssignmentResource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")
@@ -231,7 +231,7 @@ func (r *networkGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		NetworkGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_network_group_assignment.go
+++ b/internal/provider/resources/resource_network_group_assignment.go
@@ -131,7 +131,7 @@ func (r *networkGroupAssignmentResource) Create(
 		NetworkGroupAssignmentsPost(ctx).
 		NetworkGroupAssignmentsPostRequest(*postRequest)
 	networkGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -170,7 +170,7 @@ func (r *networkGroupAssignmentResource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")
@@ -231,7 +231,7 @@ func (r *networkGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		NetworkGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_network_group_assignment.go
+++ b/internal/provider/resources/resource_network_group_assignment.go
@@ -104,6 +104,7 @@ func (r *networkGroupAssignmentResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Network Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -137,6 +138,7 @@ func (r *networkGroupAssignmentResource) Create(
 			util.GenerateErrorSummary("create", "uxi_network_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 
@@ -173,11 +175,13 @@ func (r *networkGroupAssignmentResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	networkGroupAssignment := networkGroupAssignmentResponse.Items[0]
@@ -230,12 +234,14 @@ func (r *networkGroupAssignmentResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("delete", "uxi_network_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 }

--- a/internal/provider/resources/resource_network_group_assignment.go
+++ b/internal/provider/resources/resource_network_group_assignment.go
@@ -131,6 +131,7 @@ func (r *networkGroupAssignmentResource) Create(
 		NetworkGroupAssignmentsPost(ctx).
 		NetworkGroupAssignmentsPostRequest(*postRequest)
 	networkGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -169,6 +170,7 @@ func (r *networkGroupAssignmentResource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")
@@ -229,6 +231,7 @@ func (r *networkGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		NetworkGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_network_group_assignment.go
+++ b/internal/provider/resources/resource_network_group_assignment.go
@@ -131,9 +131,7 @@ func (r *networkGroupAssignmentResource) Create(
 		NetworkGroupAssignmentsPost(ctx).
 		NetworkGroupAssignmentsPostRequest(*postRequest)
 	networkGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("create", "uxi_network_group_assignment"),
@@ -142,6 +140,8 @@ func (r *networkGroupAssignmentResource) Create(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(networkGroupAssignment.Id)
 	plan.GroupID = types.StringValue(networkGroupAssignment.Group.Id)
@@ -170,9 +170,7 @@ func (r *networkGroupAssignmentResource) Read(
 		NetworkGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	networkGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_network_group_assignment")
 
 	if errorPresent {
@@ -180,6 +178,8 @@ func (r *networkGroupAssignmentResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -231,9 +231,7 @@ func (r *networkGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		NetworkGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -247,6 +245,8 @@ func (r *networkGroupAssignmentResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *networkGroupAssignmentResource) ImportState(

--- a/internal/provider/resources/resource_sensor.go
+++ b/internal/provider/resources/resource_sensor.go
@@ -134,6 +134,7 @@ func (r *sensorResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Group. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -176,11 +177,13 @@ func (r *sensorResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(sensorResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	sensor := sensorResponse.Items[0]
@@ -226,6 +229,7 @@ func (r *sensorResource) Update(
 		pcapMode, err := config_api_client.NewPcapModeFromValue(*plannedPcapMode)
 		if err != nil {
 			resp.Diagnostics.AddError(errorSummary, err.Error())
+
 			return
 		}
 		patchRequest.PcapMode = pcapMode
@@ -240,6 +244,7 @@ func (r *sensorResource) Update(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 

--- a/internal/provider/resources/resource_sensor.go
+++ b/internal/provider/resources/resource_sensor.go
@@ -171,7 +171,7 @@ func (r *sensorResource) Read(
 		SensorsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")
@@ -240,7 +240,7 @@ func (r *sensorResource) Update(
 		SensorsPatch(ctx, plan.ID.ValueString()).
 		SensorsPatchRequest(*patchRequest)
 	sensor, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 

--- a/internal/provider/resources/resource_sensor.go
+++ b/internal/provider/resources/resource_sensor.go
@@ -171,7 +171,7 @@ func (r *sensorResource) Read(
 		SensorsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")
@@ -240,7 +240,7 @@ func (r *sensorResource) Update(
 		SensorsPatch(ctx, plan.ID.ValueString()).
 		SensorsPatchRequest(*patchRequest)
 	sensor, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 

--- a/internal/provider/resources/resource_sensor.go
+++ b/internal/provider/resources/resource_sensor.go
@@ -171,6 +171,7 @@ func (r *sensorResource) Read(
 		SensorsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")
@@ -239,6 +240,7 @@ func (r *sensorResource) Update(
 		SensorsPatch(ctx, plan.ID.ValueString()).
 		SensorsPatchRequest(*patchRequest)
 	sensor, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 

--- a/internal/provider/resources/resource_sensor.go
+++ b/internal/provider/resources/resource_sensor.go
@@ -171,9 +171,7 @@ func (r *sensorResource) Read(
 		SensorsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor")
 
 	if errorPresent {
@@ -181,6 +179,8 @@ func (r *sensorResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(sensorResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -240,8 +240,6 @@ func (r *sensorResource) Update(
 		SensorsPatch(ctx, plan.ID.ValueString()).
 		SensorsPatchRequest(*patchRequest)
 	sensor, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
-
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -249,6 +247,8 @@ func (r *sensorResource) Update(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(sensor.Id)
 	plan.Name = types.StringValue(sensor.Name)

--- a/internal/provider/resources/resource_sensor_group_assignment.go
+++ b/internal/provider/resources/resource_sensor_group_assignment.go
@@ -101,6 +101,7 @@ func (r *sensorGroupAssignmentResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Sensor Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -134,6 +135,7 @@ func (r *sensorGroupAssignmentResource) Create(
 			util.GenerateErrorSummary("create", "uxi_sensor_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 
@@ -170,11 +172,13 @@ func (r *sensorGroupAssignmentResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(sensorGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -225,12 +229,14 @@ func (r *sensorGroupAssignmentResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("delete", "uxi_sensor_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 }

--- a/internal/provider/resources/resource_sensor_group_assignment.go
+++ b/internal/provider/resources/resource_sensor_group_assignment.go
@@ -128,9 +128,7 @@ func (r *sensorGroupAssignmentResource) Create(
 		SensorGroupAssignmentsPost(ctx).
 		SensorGroupAssignmentsPostRequest(*postRequest)
 	sensorGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("create", "uxi_sensor_group_assignment"),
@@ -139,6 +137,8 @@ func (r *sensorGroupAssignmentResource) Create(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(sensorGroupAssignment.Id)
 	plan.GroupID = types.StringValue(sensorGroupAssignment.Group.Id)
@@ -167,9 +167,7 @@ func (r *sensorGroupAssignmentResource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")
 
 	if errorPresent {
@@ -177,6 +175,8 @@ func (r *sensorGroupAssignmentResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(sensorGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -226,9 +226,7 @@ func (r *sensorGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		SensorGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -242,6 +240,8 @@ func (r *sensorGroupAssignmentResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *sensorGroupAssignmentResource) ImportState(

--- a/internal/provider/resources/resource_sensor_group_assignment.go
+++ b/internal/provider/resources/resource_sensor_group_assignment.go
@@ -128,7 +128,7 @@ func (r *sensorGroupAssignmentResource) Create(
 		SensorGroupAssignmentsPost(ctx).
 		SensorGroupAssignmentsPostRequest(*postRequest)
 	sensorGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -167,7 +167,7 @@ func (r *sensorGroupAssignmentResource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")
@@ -226,7 +226,7 @@ func (r *sensorGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		SensorGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_sensor_group_assignment.go
+++ b/internal/provider/resources/resource_sensor_group_assignment.go
@@ -128,6 +128,7 @@ func (r *sensorGroupAssignmentResource) Create(
 		SensorGroupAssignmentsPost(ctx).
 		SensorGroupAssignmentsPostRequest(*postRequest)
 	sensorGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -166,6 +167,7 @@ func (r *sensorGroupAssignmentResource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")
@@ -224,6 +226,7 @@ func (r *sensorGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		SensorGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_sensor_group_assignment.go
+++ b/internal/provider/resources/resource_sensor_group_assignment.go
@@ -128,7 +128,7 @@ func (r *sensorGroupAssignmentResource) Create(
 		SensorGroupAssignmentsPost(ctx).
 		SensorGroupAssignmentsPostRequest(*postRequest)
 	sensorGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -167,7 +167,7 @@ func (r *sensorGroupAssignmentResource) Read(
 		SensorGroupAssignmentsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_sensor_group_assignment")
@@ -226,7 +226,7 @@ func (r *sensorGroupAssignmentResource) Delete(
 	request := r.client.ConfigurationAPI.
 		SensorGroupAssignmentsDelete(ctx, state.ID.ValueString())
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_service.go
+++ b/internal/provider/resources/resource_service.go
@@ -143,7 +143,7 @@ func (r *serviceTestResource) Read(
 		ServiceTestsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/resource_service.go
+++ b/internal/provider/resources/resource_service.go
@@ -143,7 +143,7 @@ func (r *serviceTestResource) Read(
 		ServiceTestsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/resource_service.go
+++ b/internal/provider/resources/resource_service.go
@@ -106,6 +106,7 @@ func (r *serviceTestResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Group. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -148,11 +149,13 @@ func (r *serviceTestResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(sensorResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	serviceTest := sensorResponse.Items[0]

--- a/internal/provider/resources/resource_service.go
+++ b/internal/provider/resources/resource_service.go
@@ -143,9 +143,7 @@ func (r *serviceTestResource) Read(
 		ServiceTestsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")
 
 	if errorPresent {
@@ -153,6 +151,8 @@ func (r *serviceTestResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(sensorResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)

--- a/internal/provider/resources/resource_service.go
+++ b/internal/provider/resources/resource_service.go
@@ -143,6 +143,7 @@ func (r *serviceTestResource) Read(
 		ServiceTestsGet(ctx).
 		Id(state.ID.ValueString())
 	sensorResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test")

--- a/internal/provider/resources/resource_service_group_assignment.go
+++ b/internal/provider/resources/resource_service_group_assignment.go
@@ -101,6 +101,7 @@ func (r *serviceTestGroupAssignmentResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Service Test Group Assignment. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -134,6 +135,7 @@ func (r *serviceTestGroupAssignmentResource) Create(
 			util.GenerateErrorSummary("create", "uxi_service_test_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 
@@ -172,11 +174,13 @@ func (r *serviceTestGroupAssignmentResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(serviceTestGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 	serviceTestGroupAssignment := serviceTestGroupAssignmentResponse.Items[0]
@@ -230,12 +234,14 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
+
 			return
 		}
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("delete", "uxi_service_test_group_assignment"),
 			errorDetail,
 		)
+
 		return
 	}
 }

--- a/internal/provider/resources/resource_service_group_assignment.go
+++ b/internal/provider/resources/resource_service_group_assignment.go
@@ -128,7 +128,7 @@ func (r *serviceTestGroupAssignmentResource) Create(
 		ServiceTestGroupAssignmentsPost(ctx).
 		ServiceTestGroupAssignmentsPostRequest(*postRequest)
 	serviceTestGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -169,7 +169,7 @@ func (r *serviceTestGroupAssignmentResource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")
@@ -231,7 +231,7 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 		ServiceTestGroupAssignmentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_service_group_assignment.go
+++ b/internal/provider/resources/resource_service_group_assignment.go
@@ -128,6 +128,7 @@ func (r *serviceTestGroupAssignmentResource) Create(
 		ServiceTestGroupAssignmentsPost(ctx).
 		ServiceTestGroupAssignmentsPostRequest(*postRequest)
 	serviceTestGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -168,6 +169,7 @@ func (r *serviceTestGroupAssignmentResource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")
@@ -229,6 +231,7 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 		ServiceTestGroupAssignmentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_service_group_assignment.go
+++ b/internal/provider/resources/resource_service_group_assignment.go
@@ -128,7 +128,7 @@ func (r *serviceTestGroupAssignmentResource) Create(
 		ServiceTestGroupAssignmentsPost(ctx).
 		ServiceTestGroupAssignmentsPostRequest(*postRequest)
 	serviceTestGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {
@@ -169,7 +169,7 @@ func (r *serviceTestGroupAssignmentResource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")
@@ -231,7 +231,7 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 		ServiceTestGroupAssignmentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	if errorPresent {

--- a/internal/provider/resources/resource_service_group_assignment.go
+++ b/internal/provider/resources/resource_service_group_assignment.go
@@ -128,9 +128,7 @@ func (r *serviceTestGroupAssignmentResource) Create(
 		ServiceTestGroupAssignmentsPost(ctx).
 		ServiceTestGroupAssignmentsPostRequest(*postRequest)
 	serviceTestGroupAssignment, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		resp.Diagnostics.AddError(
 			util.GenerateErrorSummary("create", "uxi_service_test_group_assignment"),
@@ -139,6 +137,8 @@ func (r *serviceTestGroupAssignmentResource) Create(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	plan.ID = types.StringValue(serviceTestGroupAssignment.Id)
 	plan.GroupID = types.StringValue(serviceTestGroupAssignment.Group.Id)
@@ -169,9 +169,7 @@ func (r *serviceTestGroupAssignmentResource) Read(
 	serviceTestGroupAssignmentResponse, response, err := util.RetryForTooManyRequests(
 		request.Execute,
 	)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_service_test_group_assignment")
 
 	if errorPresent {
@@ -179,6 +177,8 @@ func (r *serviceTestGroupAssignmentResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(serviceTestGroupAssignmentResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
@@ -231,9 +231,7 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 		ServiceTestGroupAssignmentsDelete(ctx, state.ID.ValueString())
 
 	_, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	if errorPresent {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
@@ -247,6 +245,8 @@ func (r *serviceTestGroupAssignmentResource) Delete(
 
 		return
 	}
+
+	defer response.Body.Close()
 }
 
 func (r *serviceTestGroupAssignmentResource) ImportState(

--- a/internal/provider/resources/resource_wired_network.go
+++ b/internal/provider/resources/resource_wired_network.go
@@ -118,6 +118,7 @@ func (r *wiredNetworkResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Wired Network. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -160,11 +161,13 @@ func (r *wiredNetworkResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 

--- a/internal/provider/resources/resource_wired_network.go
+++ b/internal/provider/resources/resource_wired_network.go
@@ -155,7 +155,7 @@ func (r *wiredNetworkResource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/resource_wired_network.go
+++ b/internal/provider/resources/resource_wired_network.go
@@ -155,9 +155,7 @@ func (r *wiredNetworkResource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")
 
 	if errorPresent {
@@ -165,6 +163,8 @@ func (r *wiredNetworkResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)

--- a/internal/provider/resources/resource_wired_network.go
+++ b/internal/provider/resources/resource_wired_network.go
@@ -155,7 +155,7 @@ func (r *wiredNetworkResource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/resource_wired_network.go
+++ b/internal/provider/resources/resource_wired_network.go
@@ -155,6 +155,7 @@ func (r *wiredNetworkResource) Read(
 		WiredNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wired_network")

--- a/internal/provider/resources/resource_wireless_network.go
+++ b/internal/provider/resources/resource_wireless_network.go
@@ -166,7 +166,7 @@ func (r *wirelessNetworkResource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/resource_wireless_network.go
+++ b/internal/provider/resources/resource_wireless_network.go
@@ -129,6 +129,7 @@ func (r *wirelessNetworkResource) Configure(
 			"Unexpected Data Source Configure Type",
 			"Resource type: Wireless Network. Please report this issue to the provider developers.",
 		)
+
 		return
 	}
 
@@ -171,11 +172,13 @@ func (r *wirelessNetworkResource) Read(
 
 	if errorPresent {
 		resp.Diagnostics.AddError(errorSummary, errorDetail)
+
 		return
 	}
 
 	if len(networkResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)
+
 		return
 	}
 

--- a/internal/provider/resources/resource_wireless_network.go
+++ b/internal/provider/resources/resource_wireless_network.go
@@ -166,6 +166,7 @@ func (r *wirelessNetworkResource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
+	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/resource_wireless_network.go
+++ b/internal/provider/resources/resource_wireless_network.go
@@ -166,7 +166,7 @@ func (r *wirelessNetworkResource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
 
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")

--- a/internal/provider/resources/resource_wireless_network.go
+++ b/internal/provider/resources/resource_wireless_network.go
@@ -166,9 +166,7 @@ func (r *wirelessNetworkResource) Read(
 		WirelessNetworksGet(ctx).
 		Id(state.ID.ValueString())
 	networkResponse, response, err := util.RetryForTooManyRequests(request.Execute)
-	defer response.Body.Close()
 	errorPresent, errorDetail := util.RaiseForStatus(response, err)
-
 	errorSummary := util.GenerateErrorSummary("read", "uxi_wireless_network")
 
 	if errorPresent {
@@ -176,6 +174,8 @@ func (r *wirelessNetworkResource) Read(
 
 		return
 	}
+
+	defer response.Body.Close()
 
 	if len(networkResponse.Items) != 1 {
 		resp.State.RemoveResource(ctx)

--- a/internal/provider/util/error_handling.go
+++ b/internal/provider/util/error_handling.go
@@ -34,8 +34,8 @@ func RaiseForStatus(response *http.Response, err error) (bool, string) {
 				)
 			} else if message, ok := data["message"]; ok {
 				detail = message.(string)
-				if debugId, ok := data["debugId"]; ok {
-					detail += "\nDebugID: " + debugId.(string)
+				if debugID, ok := data["debugId"]; ok {
+					detail += "\nDebugID: " + debugID.(string)
 				}
 			} else {
 				detail = "Unexpected error: " + e.Error()

--- a/internal/provider/util/error_handling.go
+++ b/internal/provider/util/error_handling.go
@@ -46,6 +46,7 @@ func RaiseForStatus(response *http.Response, err error) (bool, string) {
 
 		return true, detail
 	}
+
 	return false, ""
 }
 

--- a/internal/provider/util/group.go
+++ b/internal/provider/util/group.go
@@ -10,5 +10,6 @@ import (
 
 func IsRoot(group config_api_client.GroupsGetItem) bool {
 	_, set := group.Parent.Get().GetIdOk()
+
 	return !set
 }

--- a/pkg/config-api-client/test/api_configuration_test.go
+++ b/pkg/config-api-client/test/api_configuration_test.go
@@ -53,6 +53,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		modelNumber := "model_number"
 		wifiMacAddress := "wifi_mac_address"
@@ -111,6 +112,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentsPatch(context.Background(), "uid").
 			AgentsPatchRequest(agentsPatchRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -139,6 +141,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentsDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -169,6 +172,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -207,6 +211,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPost(context.Background()).
 			GroupsPostRequest(*groupsPostRequest).Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -237,6 +242,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPatch(context.Background(), "node").
 			GroupsPatchRequest(*groupsPatchRequest).Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -257,6 +263,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -294,6 +301,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		WifiMacAddress := "wifi_mac_address"
 		EthernetMacAddress := "ethernet_mac_address"
@@ -362,6 +370,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorsPatch(context.Background(), "uid").
 			SensorsPatchRequest(sensorsPatchRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -409,6 +418,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -449,6 +459,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentGroupAssignmentsPost(context.Background()).
 			AgentGroupAssignmentsPostRequest(*postRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -468,6 +479,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentGroupAssignmentDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -496,6 +508,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -536,6 +549,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorGroupAssignmentsPost(context.Background()).
 			SensorGroupAssignmentsPostRequest(*postRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -555,6 +569,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			SensorGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -591,6 +606,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -653,6 +669,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -706,6 +723,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -746,6 +764,7 @@ func TestConfigurationAPI(t *testing.T) {
 			NetworkGroupAssignmentsPost(context.Background()).
 			NetworkGroupAssignmentsPostRequest(*postRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -765,6 +784,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			NetworkGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -793,6 +813,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -833,6 +854,7 @@ func TestConfigurationAPI(t *testing.T) {
 			ServiceTestGroupAssignmentsPost(context.Background()).
 			ServiceTestGroupAssignmentsPostRequest(*postRequest).
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -852,6 +874,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			ServiceTestGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)

--- a/pkg/config-api-client/test/api_configuration_test.go
+++ b/pkg/config-api-client/test/api_configuration_test.go
@@ -53,7 +53,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		modelNumber := "model_number"
 		wifiMacAddress := "wifi_mac_address"
@@ -112,7 +112,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentsPatch(context.Background(), "uid").
 			AgentsPatchRequest(agentsPatchRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -141,7 +141,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentsDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -172,7 +172,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -211,7 +211,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPost(context.Background()).
 			GroupsPostRequest(*groupsPostRequest).Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -242,7 +242,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPatch(context.Background(), "node").
 			GroupsPatchRequest(*groupsPatchRequest).Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -263,7 +263,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -301,7 +301,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		WifiMacAddress := "wifi_mac_address"
 		EthernetMacAddress := "ethernet_mac_address"
@@ -370,7 +370,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorsPatch(context.Background(), "uid").
 			SensorsPatchRequest(sensorsPatchRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -418,7 +418,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -459,7 +459,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentGroupAssignmentsPost(context.Background()).
 			AgentGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -479,7 +479,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentGroupAssignmentDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -508,7 +508,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -549,7 +549,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorGroupAssignmentsPost(context.Background()).
 			SensorGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -569,7 +569,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			SensorGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -606,7 +606,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -669,7 +669,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -723,7 +723,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -764,7 +764,7 @@ func TestConfigurationAPI(t *testing.T) {
 			NetworkGroupAssignmentsPost(context.Background()).
 			NetworkGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -784,7 +784,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			NetworkGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -813,7 +813,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -854,7 +854,7 @@ func TestConfigurationAPI(t *testing.T) {
 			ServiceTestGroupAssignmentsPost(context.Background()).
 			ServiceTestGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -874,7 +874,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			ServiceTestGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		// defer httpRes.Body.Close()
+		defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)

--- a/pkg/config-api-client/test/api_configuration_test.go
+++ b/pkg/config-api-client/test/api_configuration_test.go
@@ -53,15 +53,15 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		modelNumber := "model_number"
+
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
 		notes := "notes"
 		pcapMode := "pcap_mode"
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.AgentsResponse{
 			Items: []config_api_client.AgentItem{
@@ -112,13 +112,13 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentsPatch(context.Background(), "uid").
 			AgentsPatchRequest(agentsPatchRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		wifiMacAddress := "wifi_mac_address"
+
 		ethernetMacAddress := "ethernet_mac_address"
 		modelNumber := "model_number"
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.AgentsPatchResponse{
 			Id:                 "uid",
@@ -141,9 +141,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 
@@ -172,9 +172,9 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.GroupsGetResponse{
 			Items: []config_api_client.GroupsGetItem{
@@ -211,9 +211,9 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPost(context.Background()).
 			GroupsPostRequest(*groupsPostRequest).Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.GroupsPostResponse{
 			Id:     "node",
@@ -242,9 +242,9 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPatch(context.Background(), "node").
 			GroupsPatchRequest(*groupsPatchRequest).Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.GroupsPatchResponse{
 			Id:     "node",
@@ -263,9 +263,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 
@@ -301,17 +301,17 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		WifiMacAddress := "wifi_mac_address"
+
 		EthernetMacAddress := "ethernet_mac_address"
 		AddressNote := "address_note"
 		var Longitude float32 = 0.0
 		var Latitude float32 = 0.0
 		Notes := "notes"
 		pcapMode := "light"
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.SensorsResponse{
 			Items: []config_api_client.SensorItem{
@@ -370,14 +370,14 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorsPatch(context.Background(), "uid").
 			SensorsPatchRequest(sensorsPatchRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		wifiMacAddress := "wifi_mac_address"
+
 		ethernetMacAddress := "ethernet_mac_address"
 		var longitude float32 = 0.0
 		var latitude float32 = 0.0
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.SensorsPatchResponse{
 			Id:                 "uid",
@@ -418,9 +418,9 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.AgentGroupAssignmentsResponse{
 			Items: []config_api_client.AgentGroupAssignmentsItem{
@@ -459,9 +459,9 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentGroupAssignmentsPost(context.Background()).
 			AgentGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.AgentGroupAssignmentResponse{
 			Id:    "uid",
@@ -479,9 +479,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentGroupAssignmentDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 
@@ -508,9 +508,9 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.SensorGroupAssignmentsResponse{
 			Items: []config_api_client.SensorGroupAssignmentsItem{
@@ -549,9 +549,9 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorGroupAssignmentsPost(context.Background()).
 			SensorGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.SensorGroupAssignmentResponse{
 			Id:     "uid",
@@ -569,9 +569,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			SensorGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 
@@ -606,13 +606,13 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		security := "security"
+
 		dnsLookupDomain := "dns_lookup_domain"
 		var vlanId int32 = 1
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.WiredNetworksResponse{
 			Items: []config_api_client.WiredNetworksItem{
@@ -669,12 +669,12 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		security := "security"
-		dnsLookupDomain := "dns_lookup_domain"
 
+		dnsLookupDomain := "dns_lookup_domain"
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.WirelessNetworksResponse{
 			Items: []config_api_client.WirelessNetworksItem{
@@ -723,9 +723,9 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.NetworkGroupAssignmentsResponse{
 			Items: []config_api_client.NetworkGroupAssignmentsItem{
@@ -764,9 +764,9 @@ func TestConfigurationAPI(t *testing.T) {
 			NetworkGroupAssignmentsPost(context.Background()).
 			NetworkGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.NetworkGroupAssignmentsPostResponse{
 			Id:      "uid",
@@ -784,9 +784,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			NetworkGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 
@@ -813,9 +813,9 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.ServiceTestGroupAssignmentsResponse{
 			Items: []config_api_client.ServiceTestGroupAssignmentsItem{
@@ -854,9 +854,9 @@ func TestConfigurationAPI(t *testing.T) {
 			ServiceTestGroupAssignmentsPost(context.Background()).
 			ServiceTestGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 		assert.Equal(t, resp, &config_api_client.ServiceTestGroupAssignmentsPostResponse{
 			Id:          "uid",
@@ -874,9 +874,9 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			ServiceTestGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
-
 		require.Nil(t, err)
+
+		defer httpRes.Body.Close()
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
 	})
 }

--- a/pkg/config-api-client/test/api_configuration_test.go
+++ b/pkg/config-api-client/test/api_configuration_test.go
@@ -53,7 +53,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		modelNumber := "model_number"
 		wifiMacAddress := "wifi_mac_address"
@@ -112,7 +112,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentsPatch(context.Background(), "uid").
 			AgentsPatchRequest(agentsPatchRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -141,7 +141,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -172,7 +172,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -211,7 +211,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPost(context.Background()).
 			GroupsPostRequest(*groupsPostRequest).Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -242,7 +242,7 @@ func TestConfigurationAPI(t *testing.T) {
 		resp, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsPatch(context.Background(), "node").
 			GroupsPatchRequest(*groupsPatchRequest).Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -263,7 +263,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			GroupsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -301,7 +301,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		WifiMacAddress := "wifi_mac_address"
 		EthernetMacAddress := "ethernet_mac_address"
@@ -370,7 +370,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorsPatch(context.Background(), "uid").
 			SensorsPatchRequest(sensorsPatchRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		wifiMacAddress := "wifi_mac_address"
 		ethernetMacAddress := "ethernet_mac_address"
@@ -418,7 +418,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -459,7 +459,7 @@ func TestConfigurationAPI(t *testing.T) {
 			AgentGroupAssignmentsPost(context.Background()).
 			AgentGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -479,7 +479,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			AgentGroupAssignmentDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -508,7 +508,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -549,7 +549,7 @@ func TestConfigurationAPI(t *testing.T) {
 			SensorGroupAssignmentsPost(context.Background()).
 			SensorGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -569,7 +569,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			SensorGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -606,7 +606,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -669,7 +669,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		security := "security"
 		dnsLookupDomain := "dns_lookup_domain"
@@ -723,7 +723,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -764,7 +764,7 @@ func TestConfigurationAPI(t *testing.T) {
 			NetworkGroupAssignmentsPost(context.Background()).
 			NetworkGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -784,7 +784,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			NetworkGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)
@@ -813,7 +813,7 @@ func TestConfigurationAPI(t *testing.T) {
 			Limit(10).
 			Next("some-cursor").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -854,7 +854,7 @@ func TestConfigurationAPI(t *testing.T) {
 			ServiceTestGroupAssignmentsPost(context.Background()).
 			ServiceTestGroupAssignmentsPostRequest(*postRequest).
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -874,7 +874,7 @@ func TestConfigurationAPI(t *testing.T) {
 		_, httpRes, err := apiClient.ConfigurationAPI.
 			ServiceTestGroupAssignmentsDelete(context.Background(), "uid").
 			Execute()
-		defer httpRes.Body.Close()
+		// defer httpRes.Body.Close()
 
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusNoContent, httpRes.StatusCode)

--- a/test/live/config/config.go
+++ b/test/live/config/config.go
@@ -10,36 +10,36 @@ package config
 // customer.
 
 // This agent is permanently on the customer
-const AgentPermanentId = "abeac07d-3c28-31be-b9e7-30002c753ed4"
+const AgentPermanentID = "abeac07d-3c28-31be-b9e7-30002c753ed4"
 
 // An agent with this serial will get provisioned
 const AgentCreateSerial = "56fb38331f19d278"
 
 // The customer ID of the acceptance test customer
-const CustomerId = "9c16d493-7649-40bc-975b-07422d227c0b"
+const CustomerID = "9c16d493-7649-40bc-975b-07422d227c0b"
 
 // The root group ID
-const GroupIdRoot = "07422d227c0b"
+const GroupIDRoot = "07422d227c0b"
 
 // This wired network is permanently on the customer
 const (
-	WiredNetworkId   = "ethernet-0ee5b46c2ef0"
+	WiredNetworkID   = "ethernet-0ee5b46c2ef0"
 	WiredNetworkName = "tf-provider-acceptance-tests-ethernet-0"
 )
 
 // This wireless network is permanently on the customer
 const (
-	WirelessNetworkId   = "ssid-bf704ff37dc0"
+	WirelessNetworkID   = "ssid-bf704ff37dc0"
 	WirelessNetworkName = "tf-provider-acceptance-tests-ssid-0"
 )
 
 // This service test is permanently on the customer
 const (
-	ServiceTestId   = "6f81e43d-76f1-4a15-aafe-4ce2371d918a"
+	ServiceTestID   = "6f81e43d-76f1-4a15-aafe-4ce2371d918a"
 	ServiceTestName = "tf-provider-acceptance-test-0"
 )
 
 // This sensor is permanently on the customer
-const SensorId = "4b031caf-cea8-411d-8928-79f518163dae"
+const SensorID = "4b031caf-cea8-411d-8928-79f518163dae"
 
 const DeviceGatewayHost = "https://device-gateway.staging.capedev.io"

--- a/test/live/datasources/agent_group_assignment_test.go
+++ b/test/live/datasources/agent_group_assignment_test.go
@@ -50,6 +50,7 @@ func TestAgentGroupAssignmentDataSource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_agent_group_assignment.my_agent_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
+
 						return util.CheckStateAgainstAgentGroupAssignment(
 							t,
 							"data.uxi_agent_group_assignment.my_agent_group_assignment",

--- a/test/live/datasources/agent_group_assignment_test.go
+++ b/test/live/datasources/agent_group_assignment_test.go
@@ -30,7 +30,7 @@ func TestAgentGroupAssignmentDataSource(t *testing.T) {
 
 					data "uxi_agent" "my_agent" {
 						filter = {
-							id = "` + config.AgentPermanentId + `"
+							id = "` + config.AgentPermanentID + `"
 						}
 					}
 

--- a/test/live/datasources/agent_test.go
+++ b/test/live/datasources/agent_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAgentDataSource(t *testing.T) {
-	agent := util.GetAgent(config.AgentPermanentId)
+	agent := util.GetAgent(config.AgentPermanentID)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() {},
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -25,7 +25,7 @@ func TestAgentDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_agent" "my_agent" {
 						filter = {
-							id = "` + config.AgentPermanentId + `"
+							id = "` + config.AgentPermanentID + `"
 						}
 					}
 				`,

--- a/test/live/datasources/group_test.go
+++ b/test/live/datasources/group_test.go
@@ -26,7 +26,7 @@ func TestGroupDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_group" "my_group" {
 						filter = {
-							id = "` + config.GroupIdRoot + `"
+							id = "` + config.GroupIDRoot + `"
 						}
 					}
 				`,
@@ -68,7 +68,7 @@ func TestGroupDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.uxi_group.my_group",
 						"parent_group_id",
-						config.GroupIdRoot,
+						config.GroupIDRoot,
 					),
 				),
 			},

--- a/test/live/datasources/group_test.go
+++ b/test/live/datasources/group_test.go
@@ -51,6 +51,7 @@ func TestGroupDataSource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupName).Id)
+
 							return nil
 						},
 					),
@@ -60,6 +61,7 @@ func TestGroupDataSource(t *testing.T) {
 						"path",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupName).Path)
+
 							return nil
 						},
 					),

--- a/test/live/datasources/network_group_assignment_test.go
+++ b/test/live/datasources/network_group_assignment_test.go
@@ -30,7 +30,7 @@ func TestNetworkGroupAssignmentDataSource(t *testing.T) {
 
 					data "uxi_wired_network" "my_network" {
 						filter = {
-							id = "` + config.WiredNetworkId + `"
+							id = "` + config.WiredNetworkID + `"
 						}
 					}
 

--- a/test/live/datasources/network_group_assignment_test.go
+++ b/test/live/datasources/network_group_assignment_test.go
@@ -50,6 +50,7 @@ func TestNetworkGroupAssignmentDataSource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
+
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"data.uxi_network_group_assignment.my_network_group_assignment",

--- a/test/live/datasources/sensor_group_assignment_test.go
+++ b/test/live/datasources/sensor_group_assignment_test.go
@@ -30,7 +30,7 @@ func TestSensorGroupAssignmentDataSource(t *testing.T) {
 
 					data "uxi_sensor" "my_sensor" {
 						filter = {
-							id = "` + config.SensorId + `"
+							id = "` + config.SensorID + `"
 						}
 					}
 

--- a/test/live/datasources/sensor_group_assignment_test.go
+++ b/test/live/datasources/sensor_group_assignment_test.go
@@ -50,6 +50,7 @@ func TestSensorGroupAssignmentDataSource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_sensor_group_assignment.my_sensor_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
+
 						return util.CheckStateAgainstSensorGroupAssignment(
 							t,
 							"data.uxi_sensor_group_assignment.my_sensor_group_assignment",

--- a/test/live/datasources/sensor_test.go
+++ b/test/live/datasources/sensor_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSensorDataSource(t *testing.T) {
-	sensor := util.GetSensor(config.SensorId)
+	sensor := util.GetSensor(config.SensorID)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -24,7 +24,7 @@ func TestSensorDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_sensor" "my_sensor" {
 						filter = {
-							id = "` + config.SensorId + `"
+							id = "` + config.SensorID + `"
 						}
 					}
 				`,

--- a/test/live/datasources/service_test.go
+++ b/test/live/datasources/service_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestServiceTestDataSource(t *testing.T) {
-	serviceTest := util.GetServiceTest(config.ServiceTestId)
+	serviceTest := util.GetServiceTest(config.ServiceTestID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -25,7 +25,7 @@ func TestServiceTestDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_service_test" "my_service_test" {
 						filter = {
-							id = "` + config.ServiceTestId + `"
+							id = "` + config.ServiceTestID + `"
 						}
 					}
 				`,

--- a/test/live/datasources/service_test_group_assignment_test.go
+++ b/test/live/datasources/service_test_group_assignment_test.go
@@ -50,6 +50,7 @@ func TestServiceTestGroupAssignmentDataSource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_service_test_group_assignment.my_service_test_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
+
 						return util.CheckStateAgainstServiceTestGroupAssignment(
 							t,
 							"data.uxi_service_test_group_assignment.my_service_test_group_assignment",

--- a/test/live/datasources/service_test_group_assignment_test.go
+++ b/test/live/datasources/service_test_group_assignment_test.go
@@ -30,7 +30,7 @@ func TestServiceTestGroupAssignmentDataSource(t *testing.T) {
 
 					data "uxi_service_test" "my_service_test" {
 						filter = {
-							id = "` + config.ServiceTestId + `"
+							id = "` + config.ServiceTestID + `"
 						}
 					}
 

--- a/test/live/datasources/wired_network_test.go
+++ b/test/live/datasources/wired_network_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWiredNetworkDataSource(t *testing.T) {
-	wiredNetwork := util.GetWiredNetwork(config.WiredNetworkId)
+	wiredNetwork := util.GetWiredNetwork(config.WiredNetworkID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -25,7 +25,7 @@ func TestWiredNetworkDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_wired_network" "my_wired_network" {
 						filter = {
-							id = "` + config.WiredNetworkId + `"
+							id = "` + config.WiredNetworkID + `"
 						}
 					}
 				`,

--- a/test/live/datasources/wireless_network_test.go
+++ b/test/live/datasources/wireless_network_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWirelessNetworkDataSource(t *testing.T) {
-	wirelessNetwork := util.GetWirelessNetwork(config.WirelessNetworkId)
+	wirelessNetwork := util.GetWirelessNetwork(config.WirelessNetworkID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -25,7 +25,7 @@ func TestWirelessNetworkDataSource(t *testing.T) {
 				Config: provider.ProviderConfig + `
 					data "uxi_wireless_network" "my_wireless_network" {
 						filter = {
-							id = "` + config.WirelessNetworkId + `"
+							id = "` + config.WirelessNetworkID + `"
 						}
 					}
 				`,

--- a/test/live/resources/agent_group_assignment_test.go
+++ b/test/live/resources/agent_group_assignment_test.go
@@ -58,6 +58,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, util.GetGroupByName(groupName).Id, value)
+
 							return nil
 						},
 					),
@@ -66,6 +67,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_agent_group_assignment.my_agent_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdBeforeRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstAgentGroupAssignment(
 							t,
 							"uxi_agent_group_assignment.my_agent_group_assignment",
@@ -116,6 +118,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, util.GetGroupByName(group2Name).Id, value)
+
 							return nil
 						},
 					),
@@ -124,6 +127,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_agent_group_assignment.my_agent_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdAfterRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstAgentGroupAssignment(
 							t,
 							"uxi_agent_group_assignment.my_agent_group_assignment",
@@ -150,6 +154,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 				util.GetAgentGroupAssignment(resourceIdAfterRecreate),
 				nil,
 			)
+
 			return nil
 		},
 	})

--- a/test/live/resources/agent_group_assignment_test.go
+++ b/test/live/resources/agent_group_assignment_test.go
@@ -22,8 +22,8 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 		group2Name = "tf_provider_acceptance_test_agent_group_assignment_resource_two"
 	)
 	var (
-		resourceIdBeforeRecreate string
-		resourceIdAfterRecreate  string
+		resourceIDBeforeRecreate string
+		resourceIDAfterRecreate  string
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -38,7 +38,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 
 					data "uxi_agent" "my_agent" {
 						filter = {
-							id = "` + config.AgentPermanentId + `"
+							id = "` + config.AgentPermanentID + `"
 						}
 					}
 
@@ -51,7 +51,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_agent_group_assignment.my_agent_group_assignment",
 						"agent_id",
-						config.AgentPermanentId,
+						config.AgentPermanentID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_agent_group_assignment.my_agent_group_assignment",
@@ -66,12 +66,12 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_agent_group_assignment.my_agent_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdBeforeRecreate = rs.Primary.ID
+						resourceIDBeforeRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstAgentGroupAssignment(
 							t,
 							"uxi_agent_group_assignment.my_agent_group_assignment",
-							*util.GetAgentGroupAssignment(resourceIdBeforeRecreate),
+							*util.GetAgentGroupAssignment(resourceIDBeforeRecreate),
 						)(s)
 					},
 				),
@@ -92,7 +92,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 
 					data "uxi_agent" "my_agent" {
 						filter = {
-							id = "` + config.AgentPermanentId + `"
+							id = "` + config.AgentPermanentID + `"
 						}
 					}
 
@@ -111,7 +111,7 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_agent_group_assignment.my_agent_group_assignment",
 						"agent_id",
-						config.AgentPermanentId,
+						config.AgentPermanentID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_agent_group_assignment.my_agent_group_assignment",
@@ -126,12 +126,12 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_agent_group_assignment.my_agent_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdAfterRecreate = rs.Primary.ID
+						resourceIDAfterRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstAgentGroupAssignment(
 							t,
 							"uxi_agent_group_assignment.my_agent_group_assignment",
-							*util.GetAgentGroupAssignment(resourceIdAfterRecreate),
+							*util.GetAgentGroupAssignment(resourceIDAfterRecreate),
 						)(s)
 					},
 				),
@@ -146,12 +146,12 @@ func TestAgentGroupAssignmentResource(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
 			assert.Equal(
 				t,
-				util.GetAgentGroupAssignment(resourceIdBeforeRecreate),
+				util.GetAgentGroupAssignment(resourceIDBeforeRecreate),
 				nil,
 			)
 			assert.Equal(
 				t,
-				util.GetAgentGroupAssignment(resourceIdAfterRecreate),
+				util.GetAgentGroupAssignment(resourceIDAfterRecreate),
 				nil,
 			)
 

--- a/test/live/resources/agent_test.go
+++ b/test/live/resources/agent_test.go
@@ -90,6 +90,7 @@ func TestAgentResource(t *testing.T) {
 		},
 		CheckDestroy: func(s *terraform.State) error {
 			assert.Equal(t, util.GetAgent(agentID), nil)
+
 			return nil
 		},
 	})

--- a/test/live/resources/agent_test.go
+++ b/test/live/resources/agent_test.go
@@ -23,7 +23,7 @@ import (
 func TestAgentResource(t *testing.T) {
 	// we provision an agent here so that we have something to delete later on
 	agentID, err := util.ProvisionAgent{
-		CustomerID:        config.CustomerId,
+		CustomerID:        config.CustomerID,
 		ProvisionToken:    os.Getenv("UXI_PROVISION_TOKEN"),
 		DeviceSerial:      config.AgentCreateSerial,
 		DeviceGatewayHost: config.DeviceGatewayHost,
@@ -33,12 +33,12 @@ func TestAgentResource(t *testing.T) {
 	}
 
 	agent := util.GetAgent(agentID)
-	updated_agent := agent
-	updated_notes := "notes"
-	updated_pcapMode := "off"
-	updated_agent.Name = "tf_provider_acceptance_test_agent_resource_updated_name"
-	updated_agent.Notes = *config_api_client.NewNullableString(&updated_notes)
-	updated_agent.PcapMode = *config_api_client.NewNullableString(&updated_pcapMode)
+	updatedAgent := agent
+	updatedNotes := "notes"
+	updatedPcapMode := "off"
+	updatedAgent.Name = "tf_provider_acceptance_test_agent_resource_updated_name"
+	updatedAgent.Notes = *config_api_client.NewNullableString(&updatedNotes)
+	updatedAgent.PcapMode = *config_api_client.NewNullableString(&updatedPcapMode)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -81,7 +81,7 @@ func TestAgentResource(t *testing.T) {
 						notes = "notes"
 						pcap_mode = "off"
 					}`,
-				Check: shared.CheckStateAgainstAgent(t, "uxi_agent.my_agent", updated_agent),
+				Check: shared.CheckStateAgainstAgent(t, "uxi_agent.my_agent", updatedAgent),
 			},
 			// Delete
 			{

--- a/test/live/resources/group_test.go
+++ b/test/live/resources/group_test.go
@@ -32,7 +32,7 @@ func TestGroupResource(t *testing.T) {
 		groupNameGrandChildMovedToRoot   = groupNameGrandChild + "_moved_to_root"
 	)
 
-	var resourceIdBeforeRecreate string
+	var resourceIDBeforeRecreate string
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -135,10 +135,10 @@ func TestGroupResource(t *testing.T) {
 						"uxi_group.grandchild",
 						"id",
 						func(value string) error {
-							resourceIdBeforeRecreate = util.GetGroupByName(
+							resourceIDBeforeRecreate = util.GetGroupByName(
 								groupNameGrandChild,
 							).Id
-							assert.Equal(t, value, resourceIdBeforeRecreate)
+							assert.Equal(t, value, resourceIDBeforeRecreate)
 
 							return nil
 						},
@@ -205,7 +205,7 @@ func TestGroupResource(t *testing.T) {
 						"uxi_group.grandchild",
 						"id",
 						func(value string) error {
-							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+							assert.NotEqual(t, value, resourceIDBeforeRecreate)
 
 							return nil
 						},
@@ -271,7 +271,7 @@ func TestRootGroupResource(t *testing.T) {
 
 				import {
 					to = uxi_group.my_root_group
-					id = "` + config.GroupIdRoot + `"
+					id = "` + config.GroupIDRoot + `"
 				}`,
 				ExpectError: regexp.MustCompile(`The root group cannot be used as a resource`),
 			},
@@ -279,14 +279,14 @@ func TestRootGroupResource(t *testing.T) {
 	})
 }
 
-func checkGroupIsChildOfNode(actualParentGroupId, expectedParentName string) error {
-	expectedParentGroupId := util.GetGroupByName(expectedParentName).GetId()
+func checkGroupIsChildOfNode(actualParentGroupID, expectedParentName string) error {
+	expectedParentGroupID := util.GetGroupByName(expectedParentName).GetId()
 
-	if expectedParentGroupId != actualParentGroupId {
+	if expectedParentGroupID != actualParentGroupID {
 		return fmt.Errorf(
 			"expected \"%s\", but got \"%s\"",
-			expectedParentGroupId,
-			actualParentGroupId,
+			expectedParentGroupID,
+			actualParentGroupID,
 		)
 	}
 

--- a/test/live/resources/group_test.go
+++ b/test/live/resources/group_test.go
@@ -50,6 +50,7 @@ func TestGroupResource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupNameParent).Id)
+
 							return nil
 						},
 					),
@@ -77,6 +78,7 @@ func TestGroupResource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupNameParentUpdated).Id)
+
 							return nil
 						},
 					),
@@ -113,6 +115,7 @@ func TestGroupResource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupNameChild).Id)
+
 							return nil
 						},
 					),
@@ -136,6 +139,7 @@ func TestGroupResource(t *testing.T) {
 								groupNameGrandChild,
 							).Id
 							assert.Equal(t, value, resourceIdBeforeRecreate)
+
 							return nil
 						},
 					),
@@ -180,6 +184,7 @@ func TestGroupResource(t *testing.T) {
 								value,
 								util.GetGroupByName(groupNameGrandChildMovedToParent).Id,
 							)
+
 							return nil
 						},
 					),
@@ -201,6 +206,7 @@ func TestGroupResource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+
 							return nil
 						},
 					),
@@ -246,6 +252,7 @@ func TestGroupResource(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(groupNameGrandChild), nil)
 			assert.Equal(t, util.GetGroupByName(groupNameGrandChildMovedToParent), nil)
 			assert.Equal(t, util.GetGroupByName(groupNameGrandChildMovedToRoot), nil)
+
 			return nil
 		},
 	})

--- a/test/live/resources/network_group_assignment_test.go
+++ b/test/live/resources/network_group_assignment_test.go
@@ -63,6 +63,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						"group_id",
 						func(group_id string) error {
 							assert.Equal(t, group_id, util.GetGroupByName(groupName).Id)
+
 							return nil
 						},
 					),
@@ -71,6 +72,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdBeforeRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
@@ -124,6 +126,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						"group_id",
 						func(group_id string) error {
 							assert.Equal(t, group_id, util.GetGroupByName(group2Name).Id)
+
 							return nil
 						},
 					),
@@ -132,6 +135,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdAfterRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
@@ -144,6 +148,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+
 							return nil
 						},
 					),
@@ -166,6 +171,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+
 			return nil
 		},
 	})
@@ -218,6 +224,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						"group_id",
 						func(group_id string) error {
 							assert.Equal(t, group_id, util.GetGroupByName(groupName).Id)
+
 							return nil
 						},
 					),
@@ -226,6 +233,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdBeforeRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
@@ -279,6 +287,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						"group_id",
 						func(group_id string) error {
 							assert.Equal(t, group_id, util.GetGroupByName(group2Name).Id)
+
 							return nil
 						},
 					),
@@ -287,6 +296,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdAfterRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
@@ -299,6 +309,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+
 							return nil
 						},
 					),
@@ -321,6 +332,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+
 			return nil
 		},
 	})

--- a/test/live/resources/network_group_assignment_test.go
+++ b/test/live/resources/network_group_assignment_test.go
@@ -23,8 +23,8 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 	)
 
 	var (
-		resourceIdBeforeRecreate string
-		resourceIdAfterRecreate  string
+		resourceIDBeforeRecreate string
+		resourceIDAfterRecreate  string
 	)
 
 	// Test Wired Network Group Assignment
@@ -44,7 +44,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 
 					import {
 						to = uxi_wired_network.my_network
-						id = "` + config.WiredNetworkId + `"
+						id = "` + config.WiredNetworkID + `"
 					}
 
 					resource "uxi_network_group_assignment" "my_network_group_assignment" {
@@ -56,7 +56,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"network_id",
-						config.WiredNetworkId,
+						config.WiredNetworkID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_network_group_assignment.my_network_group_assignment",
@@ -71,12 +71,12 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdBeforeRecreate = rs.Primary.ID
+						resourceIDBeforeRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
-							util.GetNetworkGroupAssignment(resourceIdBeforeRecreate),
+							util.GetNetworkGroupAssignment(resourceIDBeforeRecreate),
 						)(s)
 					},
 				),
@@ -101,7 +101,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 
 					import {
 						to = uxi_wired_network.my_network
-						id = "` + config.WiredNetworkId + `"
+						id = "` + config.WiredNetworkID + `"
 					}
 
 					// the new resources we wanna update the assignment to
@@ -119,7 +119,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"network_id",
-						config.WiredNetworkId,
+						config.WiredNetworkID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_network_group_assignment.my_network_group_assignment",
@@ -134,12 +134,12 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdAfterRecreate = rs.Primary.ID
+						resourceIDAfterRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
-							util.GetNetworkGroupAssignment(resourceIdAfterRecreate),
+							util.GetNetworkGroupAssignment(resourceIDAfterRecreate),
 						)(s)
 					},
 					// Check that resource has been recreated
@@ -147,7 +147,7 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"id",
 						func(value string) error {
-							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+							assert.NotEqual(t, value, resourceIDBeforeRecreate)
 
 							return nil
 						},
@@ -169,8 +169,8 @@ func TestNetworkGroupAssignmentResourceForWiredNetwork(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			assert.Equal(t, util.GetGroupByName(groupName), nil)
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDBeforeRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDAfterRecreate), nil)
 
 			return nil
 		},
@@ -184,8 +184,8 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 	)
 
 	var (
-		resourceIdBeforeRecreate string
-		resourceIdAfterRecreate  string
+		resourceIDBeforeRecreate string
+		resourceIDAfterRecreate  string
 	)
 
 	// Test Wired Network Group Assignment
@@ -205,7 +205,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 
 					import {
 						to = uxi_wireless_network.my_network
-						id = "` + config.WirelessNetworkId + `"
+						id = "` + config.WirelessNetworkID + `"
 					}
 
 					resource "uxi_network_group_assignment" "my_network_group_assignment" {
@@ -217,7 +217,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"network_id",
-						config.WirelessNetworkId,
+						config.WirelessNetworkID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_network_group_assignment.my_network_group_assignment",
@@ -232,12 +232,12 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdBeforeRecreate = rs.Primary.ID
+						resourceIDBeforeRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
-							util.GetNetworkGroupAssignment(resourceIdBeforeRecreate),
+							util.GetNetworkGroupAssignment(resourceIDBeforeRecreate),
 						)(s)
 					},
 				),
@@ -262,7 +262,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 
 					import {
 						to = uxi_wireless_network.my_network
-						id = "` + config.WirelessNetworkId + `"
+						id = "` + config.WirelessNetworkID + `"
 					}
 
 					// the new resources we wanna update the assignment to
@@ -280,7 +280,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"network_id",
-						config.WirelessNetworkId,
+						config.WirelessNetworkID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_network_group_assignment.my_network_group_assignment",
@@ -295,12 +295,12 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_network_group_assignment.my_network_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdAfterRecreate = rs.Primary.ID
+						resourceIDAfterRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstNetworkGroupAssignment(
 							t,
 							"uxi_network_group_assignment.my_network_group_assignment",
-							util.GetNetworkGroupAssignment(resourceIdAfterRecreate),
+							util.GetNetworkGroupAssignment(resourceIDAfterRecreate),
 						)(s)
 					},
 					// Check that resource has been recreated
@@ -308,7 +308,7 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 						"uxi_network_group_assignment.my_network_group_assignment",
 						"id",
 						func(value string) error {
-							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+							assert.NotEqual(t, value, resourceIDBeforeRecreate)
 
 							return nil
 						},
@@ -330,8 +330,8 @@ func TestNetworkGroupAssignmentResourceForWirelessNetwork(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			assert.Equal(t, util.GetGroupByName(groupName), nil)
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDBeforeRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDAfterRecreate), nil)
 
 			return nil
 		},

--- a/test/live/resources/sensor_group_assignment_test.go
+++ b/test/live/resources/sensor_group_assignment_test.go
@@ -66,6 +66,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupName).Id)
+
 							return nil
 						},
 					),
@@ -74,6 +75,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_sensor_group_assignment.my_sensor_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdBeforeRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstSensorGroupAssignment(
 							t,
 							"uxi_sensor_group_assignment.my_sensor_group_assignment",
@@ -125,6 +127,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(group2Name).Id)
+
 							return nil
 						},
 					),
@@ -133,6 +136,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_sensor_group_assignment.my_sensor_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdAfterRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstSensorGroupAssignment(
 							t,
 							"uxi_sensor_group_assignment.my_sensor_group_assignment",
@@ -158,6 +162,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+
 			return nil
 		},
 	})

--- a/test/live/resources/sensor_group_assignment_test.go
+++ b/test/live/resources/sensor_group_assignment_test.go
@@ -23,9 +23,9 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 	)
 
 	var (
-		existingSensorProperties = util.GetSensor(config.SensorId)
-		resourceIdBeforeRecreate string
-		resourceIdAfterRecreate  string
+		existingSensorProperties = util.GetSensor(config.SensorID)
+		resourceIDBeforeRecreate string
+		resourceIDAfterRecreate  string
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 
 					import {
 						to = uxi_sensor.my_sensor
-						id = "` + config.SensorId + `"
+						id = "` + config.SensorID + `"
 					}
 
 					resource "uxi_sensor_group_assignment" "my_sensor_group_assignment" {
@@ -59,7 +59,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_sensor_group_assignment.my_sensor_group_assignment",
 						"sensor_id",
-						config.SensorId,
+						config.SensorID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_sensor_group_assignment.my_sensor_group_assignment",
@@ -74,12 +74,12 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_sensor_group_assignment.my_sensor_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdBeforeRecreate = rs.Primary.ID
+						resourceIDBeforeRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstSensorGroupAssignment(
 							t,
 							"uxi_sensor_group_assignment.my_sensor_group_assignment",
-							util.GetSensorGroupAssignment(resourceIdBeforeRecreate),
+							util.GetSensorGroupAssignment(resourceIDBeforeRecreate),
 						)(s)
 					},
 				),
@@ -120,7 +120,7 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_sensor_group_assignment.my_sensor_group_assignment",
 						"sensor_id",
-						config.SensorId,
+						config.SensorID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_sensor_group_assignment.my_sensor_group_assignment",
@@ -135,12 +135,12 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_sensor_group_assignment.my_sensor_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdAfterRecreate = rs.Primary.ID
+						resourceIDAfterRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstSensorGroupAssignment(
 							t,
 							"uxi_sensor_group_assignment.my_sensor_group_assignment",
-							util.GetSensorGroupAssignment(resourceIdAfterRecreate),
+							util.GetSensorGroupAssignment(resourceIDAfterRecreate),
 						)(s)
 					},
 				),
@@ -160,8 +160,8 @@ func TestSensorGroupAssignmentResource(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			assert.Equal(t, util.GetGroupByName(groupName), nil)
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDBeforeRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDAfterRecreate), nil)
 
 			return nil
 		},

--- a/test/live/resources/sensor_test.go
+++ b/test/live/resources/sensor_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestSensorResource(t *testing.T) {
-	originalSensor := util.GetSensor(config.SensorId)
+	originalSensor := util.GetSensor(config.SensorID)
 	updatedSensor := originalSensor
 	updatedSensor.Notes = *config_api_client.NewNullableString(config_api_client.PtrString("tf_provider_acceptance_test_update_notes"))
 	updatedSensor.AddressNote = *config_api_client.NewNullableString(config_api_client.PtrString("tf_provider_acceptance_test_update_address_note"))
@@ -52,7 +52,7 @@ func TestSensorResource(t *testing.T) {
 
 					import {
 						to = uxi_sensor.my_sensor
-						id = "` + config.SensorId + `"
+						id = "` + config.SensorID + `"
 					}`,
 
 				Check: shared.CheckStateAgainstSensor(t, "uxi_sensor.my_sensor", originalSensor),

--- a/test/live/resources/service_test.go
+++ b/test/live/resources/service_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestServiceTestResource(t *testing.T) {
-	serviceTest := util.GetServiceTest(config.ServiceTestId)
+	serviceTest := util.GetServiceTest(config.ServiceTestID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -47,7 +47,7 @@ func TestServiceTestResource(t *testing.T) {
 
 					import {
 						to = uxi_service_test.my_service_test
-						id = "` + config.ServiceTestId + `"
+						id = "` + config.ServiceTestID + `"
 					}`,
 
 				Check: shared.CheckStateAgainstServiceTest(

--- a/test/live/resources/service_test_group_assignment_test.go
+++ b/test/live/resources/service_test_group_assignment_test.go
@@ -23,8 +23,8 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 	)
 
 	var (
-		resourceIdBeforeRecreate string
-		resourceIdAfterRecreate  string
+		resourceIDBeforeRecreate string
+		resourceIDAfterRecreate  string
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -43,7 +43,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 
 					import {
 						to = uxi_service_test.my_service_test
-						id = "` + config.ServiceTestId + `"
+						id = "` + config.ServiceTestID + `"
 					}
 
 					resource "uxi_service_test_group_assignment" "my_service_test_group_assignment" {
@@ -55,7 +55,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_service_test_group_assignment.my_service_test_group_assignment",
 						"service_test_id",
-						config.ServiceTestId,
+						config.ServiceTestID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_service_test_group_assignment.my_service_test_group_assignment",
@@ -70,7 +70,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_service_test_group_assignment.my_service_test_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdBeforeRecreate = rs.Primary.ID
+						resourceIDBeforeRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstServiceTestGroupAssignment(
 							t,
@@ -113,7 +113,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"uxi_service_test_group_assignment.my_service_test_group_assignment",
 						"service_test_id",
-						config.ServiceTestId,
+						config.ServiceTestID,
 					),
 					resource.TestCheckResourceAttrWith(
 						"uxi_service_test_group_assignment.my_service_test_group_assignment",
@@ -128,7 +128,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 					func(s *terraform.State) error {
 						resourceName := "uxi_service_test_group_assignment.my_service_test_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
-						resourceIdAfterRecreate = rs.Primary.ID
+						resourceIDAfterRecreate = rs.Primary.ID
 
 						return util.CheckStateAgainstServiceTestGroupAssignment(
 							t,
@@ -141,7 +141,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						"uxi_service_test_group_assignment.my_service_test_group_assignment",
 						"id",
 						func(value string) error {
-							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+							assert.NotEqual(t, value, resourceIDBeforeRecreate)
 
 							return nil
 						},
@@ -163,8 +163,8 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 		CheckDestroy: func(s *terraform.State) error {
 			assert.Equal(t, util.GetGroupByName(groupName), nil)
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
-			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDBeforeRecreate), nil)
+			assert.Equal(t, util.GetAgentGroupAssignment(resourceIDAfterRecreate), nil)
 
 			return nil
 		},

--- a/test/live/resources/service_test_group_assignment_test.go
+++ b/test/live/resources/service_test_group_assignment_test.go
@@ -62,6 +62,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(groupName).Id)
+
 							return nil
 						},
 					),
@@ -70,6 +71,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_service_test_group_assignment.my_service_test_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdBeforeRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstServiceTestGroupAssignment(
 							t,
 							"uxi_service_test_group_assignment.my_service_test_group_assignment",
@@ -118,6 +120,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						"group_id",
 						func(value string) error {
 							assert.Equal(t, value, util.GetGroupByName(group2Name).Id)
+
 							return nil
 						},
 					),
@@ -126,6 +129,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						resourceName := "uxi_service_test_group_assignment.my_service_test_group_assignment"
 						rs := s.RootModule().Resources[resourceName]
 						resourceIdAfterRecreate = rs.Primary.ID
+
 						return util.CheckStateAgainstServiceTestGroupAssignment(
 							t,
 							"uxi_service_test_group_assignment.my_service_test_group_assignment",
@@ -138,6 +142,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 						"id",
 						func(value string) error {
 							assert.NotEqual(t, value, resourceIdBeforeRecreate)
+
 							return nil
 						},
 					),
@@ -160,6 +165,7 @@ func TestServiceTestGroupAssignmentResource(t *testing.T) {
 			assert.Equal(t, util.GetGroupByName(group2Name), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdBeforeRecreate), nil)
 			assert.Equal(t, util.GetAgentGroupAssignment(resourceIdAfterRecreate), nil)
+
 			return nil
 		},
 	})

--- a/test/live/resources/wired_network_test.go
+++ b/test/live/resources/wired_network_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestWiredNetworkResource(t *testing.T) {
-	wiredNetwork := util.GetWiredNetwork(config.WiredNetworkId)
+	wiredNetwork := util.GetWiredNetwork(config.WiredNetworkID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -47,7 +47,7 @@ func TestWiredNetworkResource(t *testing.T) {
 
 					import {
 						to = uxi_wired_network.wired_network_0
-						id = "` + config.WiredNetworkId + `"
+						id = "` + config.WiredNetworkID + `"
 					}`,
 
 				Check: shared.CheckStateAgainstWiredNetwork(
@@ -66,7 +66,7 @@ func TestWiredNetworkResource(t *testing.T) {
 			{
 				Config: provider.ProviderConfig + `
 				resource "uxi_wired_network" "wired_network_0" {
-					name = "` + config.WiredNetworkId + `-updated-name"
+					name = "` + config.WiredNetworkID + `-updated-name"
 				}`,
 				ExpectError: regexp.MustCompile(
 					`(?s)updating a wired_network is not supported; wired_networks can only be updated\s*through the dashboard`,

--- a/test/live/resources/wireless_network_test.go
+++ b/test/live/resources/wireless_network_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestWirelessNetworkResource(t *testing.T) {
-	wirelessNetwork := util.GetWirelessNetwork(config.WirelessNetworkId)
+	wirelessNetwork := util.GetWirelessNetwork(config.WirelessNetworkID)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -47,7 +47,7 @@ func TestWirelessNetworkResource(t *testing.T) {
 
 					import {
 						to = uxi_wireless_network.wireless_network_0
-						id = "` + config.WirelessNetworkId + `"
+						id = "` + config.WirelessNetworkID + `"
 					}`,
 
 				Check: shared.CheckStateAgainstWirelessNetwork(

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -23,10 +23,10 @@ func GetAgent(id string) config_api_client.AgentItem {
 		AgentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("agent with id `" + id + "` could not be found")
 	}

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -23,7 +23,7 @@ func GetAgent(id string) config_api_client.AgentItem {
 		AgentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ func (p ProvisionAgent) Provision() (string, error) {
 	if err != nil {
 		return id, err
 	}
-	defer resp.Body.Close()
+	// defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusCreated {

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -29,6 +29,7 @@ func GetAgent(id string) config_api_client.AgentItem {
 	if len(result.Items) != 1 {
 		panic("agent with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }
 

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -7,7 +7,7 @@ package util
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" // #nosec G501
 	"encoding/json"
 	"fmt"
 	"io"
@@ -95,7 +95,7 @@ func (p ProvisionAgent) Provision() (string, error) {
 
 func (p ProvisionAgent) generateID() (string, error) {
 	// Create an MD5 hash of the serial string
-	hasher := md5.New()
+	hasher := md5.New() // #nosec G401
 	hasher.Write([]byte(p.DeviceSerial))
 	digest := hasher.Sum(nil)
 

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -19,10 +19,11 @@ import (
 )
 
 func GetAgent(id string) config_api_client.AgentItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		AgentsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/agent.go
+++ b/test/live/util/agent.go
@@ -23,7 +23,7 @@ func GetAgent(id string) config_api_client.AgentItem {
 		AgentsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ func (p ProvisionAgent) Provision() (string, error) {
 	if err != nil {
 		return id, err
 	}
-	// defer resp.Body.Close()
+	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusCreated {

--- a/test/live/util/agent_group_assignment.go
+++ b/test/live/util/agent_group_assignment.go
@@ -24,6 +24,7 @@ func GetAgentGroupAssignment(id string) *config_api_client.AgentGroupAssignments
 	if len(result.Items) != 1 {
 		return nil
 	}
+
 	return &result.Items[0]
 }
 

--- a/test/live/util/agent_group_assignment.go
+++ b/test/live/util/agent_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetAgentGroupAssignment(id string) *config_api_client.AgentGroupAssignmentsItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		AgentGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/agent_group_assignment.go
+++ b/test/live/util/agent_group_assignment.go
@@ -14,10 +14,11 @@ import (
 )
 
 func GetAgentGroupAssignment(id string) *config_api_client.AgentGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		AgentGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/agent_group_assignment.go
+++ b/test/live/util/agent_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetAgentGroupAssignment(id string) *config_api_client.AgentGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		AgentGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/agent_group_assignment.go
+++ b/test/live/util/agent_group_assignment.go
@@ -18,10 +18,10 @@ func GetAgentGroupAssignment(id string) *config_api_client.AgentGroupAssignments
 		AgentGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		return nil
 	}

--- a/test/live/util/group.go
+++ b/test/live/util/group.go
@@ -11,7 +11,10 @@ import (
 )
 
 func GetGroupByName(name string) *config_api_client.GroupsGetItem {
-	groups, response, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	groups, response, err := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	if err != nil {
+		panic(err)
+	}
 	defer response.Body.Close()
 	for _, group := range groups.Items {
 		if group.Name == name {

--- a/test/live/util/group.go
+++ b/test/live/util/group.go
@@ -11,8 +11,8 @@ import (
 )
 
 func GetGroupByName(name string) *config_api_client.GroupsGetItem {
-	groups, _, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
-	// defer response.Body.Close()
+	groups, response, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	defer response.Body.Close()
 	for _, group := range groups.Items {
 		if group.Name == name {
 			return &group

--- a/test/live/util/group.go
+++ b/test/live/util/group.go
@@ -11,8 +11,8 @@ import (
 )
 
 func GetGroupByName(name string) *config_api_client.GroupsGetItem {
-	groups, response, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
-	defer response.Body.Close()
+	groups, _, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	// defer response.Body.Close()
 	for _, group := range groups.Items {
 		if group.Name == name {
 			return &group

--- a/test/live/util/group.go
+++ b/test/live/util/group.go
@@ -17,5 +17,6 @@ func GetGroupByName(name string) *config_api_client.GroupsGetItem {
 			return &group
 		}
 	}
+
 	return nil
 }

--- a/test/live/util/group.go
+++ b/test/live/util/group.go
@@ -11,7 +11,8 @@ import (
 )
 
 func GetGroupByName(name string) *config_api_client.GroupsGetItem {
-	groups, _, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	groups, response, _ := Client.ConfigurationAPI.GroupsGet(context.Background()).Execute()
+	defer response.Body.Close()
 	for _, group := range groups.Items {
 		if group.Name == name {
 			return &group

--- a/test/live/util/network_group_assignment.go
+++ b/test/live/util/network_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetNetworkGroupAssignment(id string) config_api_client.NetworkGroupAssignmentsItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		NetworkGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/network_group_assignment.go
+++ b/test/live/util/network_group_assignment.go
@@ -24,6 +24,7 @@ func GetNetworkGroupAssignment(id string) config_api_client.NetworkGroupAssignme
 	if len(result.Items) != 1 {
 		panic("network_group_assignment with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }
 

--- a/test/live/util/network_group_assignment.go
+++ b/test/live/util/network_group_assignment.go
@@ -14,10 +14,11 @@ import (
 )
 
 func GetNetworkGroupAssignment(id string) config_api_client.NetworkGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		NetworkGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/network_group_assignment.go
+++ b/test/live/util/network_group_assignment.go
@@ -18,10 +18,10 @@ func GetNetworkGroupAssignment(id string) config_api_client.NetworkGroupAssignme
 		NetworkGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("network_group_assignment with id `" + id + "` could not be found")
 	}

--- a/test/live/util/network_group_assignment.go
+++ b/test/live/util/network_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetNetworkGroupAssignment(id string) config_api_client.NetworkGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		NetworkGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor.go
+++ b/test/live/util/sensor.go
@@ -15,10 +15,10 @@ func GetSensor(id string) config_api_client.SensorItem {
 		SensorsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("sensor with id `" + id + "` could not be found")
 	}

--- a/test/live/util/sensor.go
+++ b/test/live/util/sensor.go
@@ -21,5 +21,6 @@ func GetSensor(id string) config_api_client.SensorItem {
 	if len(result.Items) != 1 {
 		panic("sensor with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }

--- a/test/live/util/sensor.go
+++ b/test/live/util/sensor.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetSensor(id string) config_api_client.SensorItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		SensorsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor.go
+++ b/test/live/util/sensor.go
@@ -11,10 +11,11 @@ import (
 )
 
 func GetSensor(id string) config_api_client.SensorItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		SensorsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor.go
+++ b/test/live/util/sensor.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetSensor(id string) config_api_client.SensorItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		SensorsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor_group_assignment.go
+++ b/test/live/util/sensor_group_assignment.go
@@ -14,10 +14,11 @@ import (
 )
 
 func GetSensorGroupAssignment(id string) config_api_client.SensorGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		SensorGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor_group_assignment.go
+++ b/test/live/util/sensor_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetSensorGroupAssignment(id string) config_api_client.SensorGroupAssignmentsItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		SensorGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/sensor_group_assignment.go
+++ b/test/live/util/sensor_group_assignment.go
@@ -24,6 +24,7 @@ func GetSensorGroupAssignment(id string) config_api_client.SensorGroupAssignment
 	if len(result.Items) != 1 {
 		panic("sensor_group_assignment with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }
 

--- a/test/live/util/sensor_group_assignment.go
+++ b/test/live/util/sensor_group_assignment.go
@@ -18,10 +18,10 @@ func GetSensorGroupAssignment(id string) config_api_client.SensorGroupAssignment
 		SensorGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("sensor_group_assignment with id `" + id + "` could not be found")
 	}

--- a/test/live/util/sensor_group_assignment.go
+++ b/test/live/util/sensor_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetSensorGroupAssignment(id string) config_api_client.SensorGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		SensorGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service.go
+++ b/test/live/util/service.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetServiceTest(id string) config_api_client.ServiceTestsListItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		ServiceTestsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service.go
+++ b/test/live/util/service.go
@@ -21,5 +21,6 @@ func GetServiceTest(id string) config_api_client.ServiceTestsListItem {
 	if len(result.Items) != 1 {
 		panic("service_test with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }

--- a/test/live/util/service.go
+++ b/test/live/util/service.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetServiceTest(id string) config_api_client.ServiceTestsListItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		ServiceTestsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service.go
+++ b/test/live/util/service.go
@@ -15,10 +15,10 @@ func GetServiceTest(id string) config_api_client.ServiceTestsListItem {
 		ServiceTestsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("service_test with id `" + id + "` could not be found")
 	}

--- a/test/live/util/service.go
+++ b/test/live/util/service.go
@@ -11,10 +11,11 @@ import (
 )
 
 func GetServiceTest(id string) config_api_client.ServiceTestsListItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		ServiceTestsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service_test_group_assignment.go
+++ b/test/live/util/service_test_group_assignment.go
@@ -24,6 +24,7 @@ func GetServiceTestGroupAssignment(id string) config_api_client.ServiceTestGroup
 	if len(result.Items) != 1 {
 		panic("service_test_group_assignment with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }
 

--- a/test/live/util/service_test_group_assignment.go
+++ b/test/live/util/service_test_group_assignment.go
@@ -18,10 +18,10 @@ func GetServiceTestGroupAssignment(id string) config_api_client.ServiceTestGroup
 		ServiceTestGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("service_test_group_assignment with id `" + id + "` could not be found")
 	}

--- a/test/live/util/service_test_group_assignment.go
+++ b/test/live/util/service_test_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetServiceTestGroupAssignment(id string) config_api_client.ServiceTestGroupAssignmentsItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		ServiceTestGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service_test_group_assignment.go
+++ b/test/live/util/service_test_group_assignment.go
@@ -14,10 +14,11 @@ import (
 )
 
 func GetServiceTestGroupAssignment(id string) config_api_client.ServiceTestGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		ServiceTestGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/service_test_group_assignment.go
+++ b/test/live/util/service_test_group_assignment.go
@@ -14,11 +14,11 @@ import (
 )
 
 func GetServiceTestGroupAssignment(id string) config_api_client.ServiceTestGroupAssignmentsItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		ServiceTestGroupAssignmentsGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/util.go
+++ b/test/live/util/util.go
@@ -8,5 +8,6 @@ func ConditionalProperty(property string, value *string) string {
 	if value == nil {
 		return ""
 	}
+
 	return property + `= "` + *value + `"`
 }

--- a/test/live/util/wired_network.go
+++ b/test/live/util/wired_network.go
@@ -21,5 +21,6 @@ func GetWiredNetwork(id string) config_api_client.WiredNetworksItem {
 	if len(result.Items) != 1 {
 		panic("wired_network with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }

--- a/test/live/util/wired_network.go
+++ b/test/live/util/wired_network.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetWiredNetwork(id string) config_api_client.WiredNetworksItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		WiredNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wired_network.go
+++ b/test/live/util/wired_network.go
@@ -11,10 +11,11 @@ import (
 )
 
 func GetWiredNetwork(id string) config_api_client.WiredNetworksItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		WiredNetworksGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wired_network.go
+++ b/test/live/util/wired_network.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetWiredNetwork(id string) config_api_client.WiredNetworksItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		WiredNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wired_network.go
+++ b/test/live/util/wired_network.go
@@ -15,10 +15,10 @@ func GetWiredNetwork(id string) config_api_client.WiredNetworksItem {
 		WiredNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("wired_network with id `" + id + "` could not be found")
 	}

--- a/test/live/util/wireless_network.go
+++ b/test/live/util/wireless_network.go
@@ -21,5 +21,6 @@ func GetWirelessNetwork(id string) config_api_client.WirelessNetworksItem {
 	if len(result.Items) != 1 {
 		panic("wireless_network with id `" + id + "` could not be found")
 	}
+
 	return result.Items[0]
 }

--- a/test/live/util/wireless_network.go
+++ b/test/live/util/wireless_network.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetWirelessNetwork(id string) config_api_client.WirelessNetworksItem {
-	result, response, err := Client.ConfigurationAPI.
+	result, _, err := Client.ConfigurationAPI.
 		WirelessNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
+	// defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wireless_network.go
+++ b/test/live/util/wireless_network.go
@@ -11,11 +11,11 @@ import (
 )
 
 func GetWirelessNetwork(id string) config_api_client.WirelessNetworksItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		WirelessNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	// defer response.Body.Close()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wireless_network.go
+++ b/test/live/util/wireless_network.go
@@ -11,10 +11,11 @@ import (
 )
 
 func GetWirelessNetwork(id string) config_api_client.WirelessNetworksItem {
-	result, _, err := Client.ConfigurationAPI.
+	result, response, err := Client.ConfigurationAPI.
 		WirelessNetworksGet(context.Background()).
 		Id(id).
 		Execute()
+	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/test/live/util/wireless_network.go
+++ b/test/live/util/wireless_network.go
@@ -15,10 +15,10 @@ func GetWirelessNetwork(id string) config_api_client.WirelessNetworksItem {
 		WirelessNetworksGet(context.Background()).
 		Id(id).
 		Execute()
-	defer response.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer response.Body.Close()
 	if len(result.Items) != 1 {
 		panic("wireless_network with id `" + id + "` could not be found")
 	}

--- a/test/mocked/datasources/agent_group_assignment_test.go
+++ b/test/mocked/datasources/agent_group_assignment_test.go
@@ -102,6 +102,7 @@ func TestAgentGroupAssignmentDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/agent_test.go
+++ b/test/mocked/datasources/agent_test.go
@@ -76,6 +76,7 @@ func TestAgentDataSourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstAgent(t, "data.uxi_agent.my_agent", agent),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/group_test.go
+++ b/test/mocked/datasources/group_test.go
@@ -43,7 +43,7 @@ func TestGroupDataSource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					util.MockGetGroup(util.MockRootGroupId, util.GenerateRootGroupGetResponse(), 1)
+					util.MockGetGroup(util.MockRootGroupID, util.GenerateRootGroupGetResponse(), 1)
 				},
 				Config: provider.ProviderConfig + `
 					data "uxi_group" "my_group" {

--- a/test/mocked/datasources/group_test.go
+++ b/test/mocked/datasources/group_test.go
@@ -88,6 +88,7 @@ func TestGroupDataSourceTooManyRequestsHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("data.uxi_group.my_group", "id", "id"),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/network_group_assignment_test.go
+++ b/test/mocked/datasources/network_group_assignment_test.go
@@ -102,6 +102,7 @@ func TestNetworkGroupAssignmentDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/sensor_group_assignment_test.go
+++ b/test/mocked/datasources/sensor_group_assignment_test.go
@@ -102,6 +102,7 @@ func TestSensorGroupAssignmentDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/sensor_test.go
+++ b/test/mocked/datasources/sensor_test.go
@@ -76,6 +76,7 @@ func TestSensorDataSourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstSensor(t, "data.uxi_sensor.my_sensor", sensor),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/service_test.go
+++ b/test/mocked/datasources/service_test.go
@@ -84,6 +84,7 @@ func TestServiceTestDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/service_test_group_assignment_test.go
+++ b/test/mocked/datasources/service_test_group_assignment_test.go
@@ -102,6 +102,7 @@ func TestServiceTestGroupAssignmentDataSourceTooManyRequestsHandling(t *testing.
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/wired_network_test.go
+++ b/test/mocked/datasources/wired_network_test.go
@@ -84,6 +84,7 @@ func TestWiredNetworkDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/datasources/wireless_network_test.go
+++ b/test/mocked/datasources/wireless_network_test.go
@@ -92,6 +92,7 @@ func TestWirelessNetworkDataSourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/agent_group_assignment_test.go
+++ b/test/mocked/resources/agent_group_assignment_test.go
@@ -360,6 +360,7 @@ func TestAgentGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -382,6 +383,7 @@ func TestAgentGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				ImportStateVerify: true,
 				Check: func(s *terraform.State) error {
 					assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 					return nil
 				},
 			},
@@ -410,6 +412,7 @@ func TestAgentGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				Config: provider.ProviderConfig,
 				Check: func(s *terraform.State) error {
 					assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 					return nil
 				},
 			},

--- a/test/mocked/resources/agent_test.go
+++ b/test/mocked/resources/agent_test.go
@@ -145,6 +145,7 @@ func TestAgentResourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstAgent(t, "uxi_agent.my_agent", agent),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -177,6 +178,7 @@ func TestAgentResourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstAgent(t, "uxi_agent.my_agent", updatedAgent),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -195,6 +197,7 @@ func TestAgentResourceTooManyRequestsHandling(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/group_test.go
+++ b/test/mocked/resources/group_test.go
@@ -171,7 +171,7 @@ func TestRootGroupResource(t *testing.T) {
 			// Importing the root group does not work
 			{
 				PreConfig: func() {
-					util.MockGetGroup(util.MockRootGroupId, util.GenerateRootGroupGetResponse(), 1)
+					util.MockGetGroup(util.MockRootGroupID, util.GenerateRootGroupGetResponse(), 1)
 				},
 				Config: provider.ProviderConfig + `
 				resource "uxi_group" "my_root_group" {
@@ -180,7 +180,7 @@ func TestRootGroupResource(t *testing.T) {
 
 				import {
 					to = uxi_group.my_root_group
-					id = "` + util.MockRootGroupId + `"
+					id = "` + util.MockRootGroupID + `"
 				}`,
 				ExpectError: regexp.MustCompile(`The root group cannot be used as a resource`),
 			},
@@ -193,7 +193,7 @@ func TestRootGroupResource(t *testing.T) {
 						1,
 					)
 					// to indicate the group has the root group as a parent
-					util.MockGetGroup(util.MockRootGroupId, util.GenerateRootGroupGetResponse(), 1)
+					util.MockGetGroup(util.MockRootGroupID, util.GenerateRootGroupGetResponse(), 1)
 					util.MockGetGroup(
 						"id",
 						util.GenerateGroupAttachedToRootGroupGetResponse("id", ""),

--- a/test/mocked/resources/group_test.go
+++ b/test/mocked/resources/group_test.go
@@ -266,6 +266,7 @@ func TestGroupResourceTooManyRequestsHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("uxi_group.my_group", "id", "id"),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -292,6 +293,7 @@ func TestGroupResourceTooManyRequestsHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("uxi_group.my_group", "id", "id"),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -329,6 +331,7 @@ func TestGroupResourceTooManyRequestsHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("uxi_group.my_group", "name", "name_2"),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/network_group_assignment_test.go
+++ b/test/mocked/resources/network_group_assignment_test.go
@@ -675,6 +675,7 @@ func TestNetworkGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -701,6 +702,7 @@ func TestNetworkGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -745,6 +747,7 @@ func TestNetworkGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/sensor_group_assignment_test.go
+++ b/test/mocked/resources/sensor_group_assignment_test.go
@@ -372,6 +372,7 @@ func TestSensorGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -398,6 +399,7 @@ func TestSensorGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -445,6 +447,7 @@ func TestSensorGroupAssignmentResourceTooManyRequestsHandling(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/sensor_test.go
+++ b/test/mocked/resources/sensor_test.go
@@ -166,6 +166,7 @@ func TestSensorResourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstSensor(t, "uxi_sensor.my_sensor", sensor),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -199,6 +200,7 @@ func TestSensorResourceTooManyRequestsHandling(t *testing.T) {
 					shared.CheckStateAgainstSensor(t, "uxi_sensor.my_sensor", updatedSensor),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/service_test.go
+++ b/test/mocked/resources/service_test.go
@@ -153,6 +153,7 @@ func TestServiceTestResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/service_test_group_assignment_test.go
+++ b/test/mocked/resources/service_test_group_assignment_test.go
@@ -360,6 +360,7 @@ func TestServiceTestGroupAssignmentResourceTooManyRequestsHandling(t *testing.T)
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),
@@ -385,6 +386,7 @@ func TestServiceTestGroupAssignmentResourceTooManyRequestsHandling(t *testing.T)
 				Check: resource.ComposeAggregateTestCheckFunc(
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/wired_network_test.go
+++ b/test/mocked/resources/wired_network_test.go
@@ -153,6 +153,7 @@ func TestWiredNetworkResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/resources/wireless_network_test.go
+++ b/test/mocked/resources/wireless_network_test.go
@@ -180,6 +180,7 @@ func TestWirelessNetworkResourceTooManyRequestsHandling(t *testing.T) {
 					),
 					func(s *terraform.State) error {
 						assert.Equal(t, mockTooManyRequests.Mock.Request().Counter, 0)
+
 						return nil
 					},
 				),

--- a/test/mocked/util/agent.go
+++ b/test/mocked/util/agent.go
@@ -17,6 +17,7 @@ func GenerateAgentPatchRequest(postfix string) config_api_client.AgentsPatchRequ
 	name := "name" + postfix
 	notes := "notes" + postfix
 	pcapMode, _ := config_api_client.NewPcapModeFromValue("light")
+
 	return config_api_client.AgentsPatchRequest{
 		Name:     &name,
 		Notes:    &notes,

--- a/test/mocked/util/group.go
+++ b/test/mocked/util/group.go
@@ -141,6 +141,7 @@ func GenerateGroupAttachedToRootGroupPostRequest(
 
 func GenerateGroupPatchRequest(postfix string) config_api_client.GroupsPatchRequest {
 	name := "name" + postfix
+
 	return config_api_client.GroupsPatchRequest{
 		Name: &name,
 	}

--- a/test/mocked/util/group.go
+++ b/test/mocked/util/group.go
@@ -13,20 +13,20 @@ import (
 	"github.com/aruba-uxi/terraform-provider-hpeuxi/test/shared"
 )
 
-const MockRootGroupId = "root_group_id"
+const MockRootGroupID = "root_group_id"
 
 func GenerateGroupPostResponse(
 	id string,
 	nameSuffix string,
-	parentIdSuffix string,
+	parentIDSuffix string,
 ) config_api_client.GroupsPostResponse {
-	parentId := "parent_id" + parentIdSuffix
+	parentID := "parent_id" + parentIDSuffix
 
 	return config_api_client.GroupsPostResponse{
 		Id:     id,
 		Name:   "name" + nameSuffix,
-		Parent: *config_api_client.NewParent(parentId),
-		Path:   parentId + "." + id,
+		Parent: *config_api_client.NewParent(parentID),
+		Path:   parentID + "." + id,
 		Type:   shared.GroupType,
 	}
 }
@@ -38,7 +38,7 @@ func GenerateGroupAttachedToRootGroupPostResponse(
 	return config_api_client.GroupsPostResponse{
 		Id:     id,
 		Name:   "name" + nameSuffix,
-		Parent: *config_api_client.NewParent(MockRootGroupId),
+		Parent: *config_api_client.NewParent(MockRootGroupID),
 		Path:   "root_group_id." + id,
 		Type:   shared.GroupType,
 	}
@@ -47,15 +47,15 @@ func GenerateGroupAttachedToRootGroupPostResponse(
 func GenerateGroupPatchResponse(
 	id string,
 	nameSuffix string,
-	parentIdSuffix string,
+	parentIDSuffix string,
 ) config_api_client.GroupsPatchResponse {
-	parentId := "parent_id" + parentIdSuffix
+	parentID := "parent_id" + parentIDSuffix
 
 	return config_api_client.GroupsPatchResponse{
 		Id:     id,
 		Name:   "name" + nameSuffix,
-		Parent: *config_api_client.NewParent(parentId),
-		Path:   parentId + "." + id,
+		Parent: *config_api_client.NewParent(parentID),
+		Path:   parentID + "." + id,
 		Type:   shared.GroupType,
 	}
 }
@@ -63,17 +63,17 @@ func GenerateGroupPatchResponse(
 func GenerateGroupGetResponse(
 	id string,
 	nameSuffix string,
-	parentIdSuffix string,
+	parentIDSuffix string,
 ) config_api_client.GroupsGetResponse {
-	parentId := "parent_id" + parentIdSuffix
+	parentID := "parent_id" + parentIDSuffix
 
 	return config_api_client.GroupsGetResponse{
 		Items: []config_api_client.GroupsGetItem{
 			{
 				Id:     id,
 				Name:   "name" + nameSuffix,
-				Parent: *config_api_client.NewNullableParent(config_api_client.NewParent(parentId)),
-				Path:   parentId + "." + id,
+				Parent: *config_api_client.NewNullableParent(config_api_client.NewParent(parentID)),
+				Path:   parentID + "." + id,
 				Type:   shared.GroupType,
 			},
 		},
@@ -91,7 +91,7 @@ func GenerateGroupAttachedToRootGroupGetResponse(
 			{
 				Id:     id,
 				Name:   "name" + nameSuffix,
-				Parent: *config_api_client.NewNullableParent(config_api_client.NewParent(MockRootGroupId)),
+				Parent: *config_api_client.NewNullableParent(config_api_client.NewParent(MockRootGroupID)),
 				Path:   "root_group_id." + id,
 				Type:   shared.GroupType,
 			},
@@ -105,10 +105,10 @@ func GenerateRootGroupGetResponse() config_api_client.GroupsGetResponse {
 	return config_api_client.GroupsGetResponse{
 		Items: []config_api_client.GroupsGetItem{
 			{
-				Id:     MockRootGroupId,
+				Id:     MockRootGroupID,
 				Name:   "root",
 				Parent: *config_api_client.NewNullableParent(nil),
-				Path:   MockRootGroupId,
+				Path:   MockRootGroupID,
 				Type:   shared.GroupType,
 			},
 		},
@@ -120,13 +120,13 @@ func GenerateRootGroupGetResponse() config_api_client.GroupsGetResponse {
 func GenerateNonRootGroupPostRequest(
 	id string,
 	namePostfix string,
-	parentIdPostfix string,
+	parentIDPostfix string,
 ) config_api_client.GroupsPostRequest {
-	parentId := "parent_id" + parentIdPostfix
+	parentID := "parent_id" + parentIDPostfix
 
 	return config_api_client.GroupsPostRequest{
 		Name:     "name" + namePostfix,
-		ParentId: *config_api_client.NewNullableString(&parentId),
+		ParentId: *config_api_client.NewNullableString(&parentID),
 	}
 }
 

--- a/test/mocked/util/sensor.go
+++ b/test/mocked/util/sensor.go
@@ -38,6 +38,7 @@ func GenerateSensorResponse(id string, postfix string) config_api_client.Sensors
 
 func GenerateSensorPatchRequest(postfix string) config_api_client.SensorsPatchRequest {
 	pcapMode, _ := config_api_client.NewPcapModeFromValue("light")
+
 	return config_api_client.SensorsPatchRequest{
 		Name:        config_api_client.PtrString("name" + postfix),
 		AddressNote: config_api_client.PtrString("address_note" + postfix),
@@ -48,6 +49,7 @@ func GenerateSensorPatchRequest(postfix string) config_api_client.SensorsPatchRe
 
 func GenerateSensorPatchResponse(id string, postfix string) config_api_client.SensorsPatchResponse {
 	pcapMode, _ := config_api_client.NewPcapModeFromValue("light")
+
 	return config_api_client.SensorsPatchResponse{
 		Id:                 id,
 		Serial:             "serial" + postfix,

--- a/test/mocked/util/wired_network.go
+++ b/test/mocked/util/wired_network.go
@@ -20,6 +20,7 @@ func GenerateWiredNetworkResponse(
 ) config_api_client.WiredNetworksResponse {
 	createdAt, _ := time.Parse(time.RFC3339, "2024-09-11T12:00:00.000Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2024-09-11T12:00:00.000Z")
+
 	return config_api_client.WiredNetworksResponse{
 		Items: []config_api_client.WiredNetworksItem{
 			{

--- a/test/mocked/util/wireless_network.go
+++ b/test/mocked/util/wireless_network.go
@@ -20,6 +20,7 @@ func GenerateWirelessNetworkResponse(
 ) config_api_client.WirelessNetworksResponse {
 	createdAt, _ := time.Parse(time.RFC3339, "2024-09-11T12:00:00.000Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2024-09-11T12:00:00.000Z")
+
 	return config_api_client.WirelessNetworksResponse{
 		Items: []config_api_client.WirelessNetworksItem{
 			{

--- a/test/shared/agent.go
+++ b/test/shared/agent.go
@@ -27,6 +27,7 @@ func CheckStateAgainstAgent(
 			"name",
 			func(value string) error {
 				assert.Equal(t, value, agent.Name)
+
 				return nil
 			},
 		),

--- a/test/shared/sensor.go
+++ b/test/shared/sensor.go
@@ -27,6 +27,7 @@ func CheckStateAgainstSensor(
 			"name",
 			func(value string) error {
 				assert.Equal(t, value, sensor.Name)
+
 				return nil
 			},
 		),

--- a/test/shared/shared.go
+++ b/test/shared/shared.go
@@ -71,6 +71,7 @@ func TestOptionalFloatValue(
 			if have != want {
 				return fmt.Errorf("have `%f`; but want `%f`", have, want)
 			}
+
 			return nil
 		},
 	)
@@ -78,6 +79,7 @@ func TestOptionalFloatValue(
 
 func stringToFloat64(s string) float64 {
 	val, _ := strconv.ParseFloat(s, 32)
+
 	return float64(val)
 }
 
@@ -86,5 +88,6 @@ func Int32PtrToStringPtr(value *int32) *string {
 		return nil
 	}
 	result := strconv.Itoa(int(*value))
+
 	return &result
 }

--- a/test/shared/wired_network.go
+++ b/test/shared/wired_network.go
@@ -26,6 +26,7 @@ func CheckStateAgainstWiredNetwork(
 			"name",
 			func(value string) error {
 				assert.Equal(t, value, wiredNetwork.Name)
+
 				return nil
 			},
 		),

--- a/test/shared/wireless_network.go
+++ b/test/shared/wireless_network.go
@@ -27,6 +27,7 @@ func CheckStateAgainstWirelessNetwork(
 			"name",
 			func(value string) error {
 				assert.Equal(t, value, wirelessNetwork.Name)
+
 				return nil
 			},
 		),


### PR DESCRIPTION
## Description

- **fix: make the return lint happy**
- **style: add empty line before return statements**
- **chore: update linter list**
- **fix: many http body left open memory leaks**
- **fix: ignore some false positives from gosec**
- **style: fix var names to follow style guidelines**
- **fix: undo body.Close to find segfault**
- **fix: close http response in client tests**
- **fix: close a few more http clients**
- **fix: and close some more**
- **fix: close responses in live tests**
- **fix: close responses in agent_group_assignment**
- **fix: close responses in agent_group_assignments**
- **fix: close response in service_group_assignments**
- **fix: close responses in wireless_networks**
- **fix: close response in service_test_groups**
- **fix: close response in senso_group_assignments**
- **fix: close most resonpses in resoruce_group**
- **fix: close responses in network_group_assignments**
- **fix: close the reamining provider http responses**
- **fix: close results in live tests**
- **refactor: use error instead of *string in response**
- **fix: move defer to below error check**
- **fix: move defer to after nil check for http response**
- **chore: update lint config**
- **chore: update linting config to enable ireturn**

## Related Issue(s)

- <https://jira.arubanetworks.com/browse/UXI-9700>
