### PR TITLE
fix: env var naming

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,11 +25,11 @@ generate-config-api-client: _remove-client-files
   just fmt-client
 
 setup-run:
-  grep -q "registry.terraform.io/arubauxi/hpeuxi" ~/.terraformrc && echo "Dev override found - installing provider locally" || { echo "Dev override not found - please follow README setup guide"; exit 1; }
+  grep -q "registry.terraform.io/aruba-uxi/hpeuxi" ~/.terraformrc && echo "Dev override found - installing provider locally" || { echo "Dev override not found - please follow README setup guide"; exit 1; }
   go install .
 
 remove-setup-run-dev-override:
-  sed -i '' '/registry\.terraform\.io\/arubauxi\/hpeuxi/d' ~/.terraformrc
+  sed -i '' '/registry\.terraform\.io\/aruba-uxi\/hpeuxi/d' ~/.terraformrc
 
 build-local:
   go run github.com/goreleaser/goreleaser/v2@latest release --clean --skip=publish,validate

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export HPEUXI_CLIENT_SECRET=<hpeuxi_client_secret>
 To override the host against which the API requests are made, use the env var as shown below, else UXI production is used as the default.
 
 ```bash
-export HPEUXI_HOST_OVERRIDE=https://api.staging.capedev.io
+export HPEUXI_HOST_OVERRIDE=api.staging.capedev.io
 ```
 
 ### Initialize Terraform working directory:
@@ -123,7 +123,7 @@ Example `~/.terraformrc` file
 ```
 provider_installation {
   dev_overrides {
-      "registry.terraform.io/arubauxi/hpeuxi" = "/Users/<user>/go/bin"
+      "registry.terraform.io/aruba-uxi/hpeuxi" = "/Users/<user>/go/bin"
   }
   direct {}
 }
@@ -164,9 +164,9 @@ Set the `GREENLAKE_UXI_CLIENT_ID` and `GREENLAKE_UXI_CLIENT_SECRET` environment 
 environment.
 
 ```bash
-export GREENLAKE_UXI_CLIENT_ID=<client_id>
-export GREENLAKE_UXI_CLIENT_SECRET=<client_secret>
-export UXI_HOST=api.staging.capedev.io
+export HPEUXI_CLIENT_ID=<client_id>
+export HPEUXI_CLIENT_SECRET=<client_secret>
+export HPEUXI_HOST_OVERRIDE=api.staging.capedev.io
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -88,8 +88,14 @@ resource "hpeuxi_sensor_group_assignment" "my_uxi_sensor_group_assignment" {
 ### Export API client credentials as environment variables
 
 ```bash
-export GREENLAKE_UXI_CLIENT_ID=<greenlake_uxi_client_id>
-export GREENLAKE_UXI_CLIENT_SECRET=<greenlake_uxi_client_secret>
+export HPEUXI_CLIENT_ID=<hpeuxi_client_id>
+export HPEUXI_CLIENT_SECRET=<hpeuxi_client_secret>
+```
+
+To override the host against which the API requests are made, use the env var as shown below, else UXI production is used as the default.
+
+```bash
+export HPEUXI_HOST_OVERRIDE=https://api.staging.capedev.io
 ```
 
 ### Initialize Terraform working directory:

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,5 @@ provider "hpeuxi" {
 
 ### Optional
 
-- `client_id` (String) The Client ID as obtained from HPE GreenLake API client credentials. It is recommended that this configuration is left blank and the Client ID is exported as the `GREENLAKE_UXI_CLIENT_ID` environment variable instead.
-- `client_secret` (String, Sensitive) The Client Secret as obtained from HPE GreenLake API client credentials. It is recommended that this configuration is left blank and the Client Secret is exported as the `GREENLAKE_UXI_CLIENT_SECRET` environment variable instead.
+- `client_id` (String) The Client ID as obtained from HPE GreenLake API client credentials. It is recommended that this configuration is left blank and the Client ID is exported as the `HPEUXI_CLIENT_ID` environment variable instead.
+- `client_secret` (String, Sensitive) The Client Secret as obtained from HPE GreenLake API client credentials. It is recommended that this configuration is left blank and the Client Secret is exported as the `HPEUXI_CLIENT_SECRET` environment variable instead.

--- a/internal/provider/config/config.go
+++ b/internal/provider/config/config.go
@@ -28,7 +28,7 @@ func getEnv(key, fallback string) string {
 }
 
 func InitializeConfig() {
-	Host = getEnv("UXI_HOST", UXIDefaultHost)
-	ClientID = os.Getenv("GREENLAKE_UXI_CLIENT_ID")
-	ClientSecret = os.Getenv("GREENLAKE_UXI_CLIENT_SECRET")
+	Host = getEnv("HPEUXI_HOST_OVERRIDE", UXIDefaultHost)
+	ClientID = os.Getenv("HPEUXI_CLIENT_ID")
+	ClientSecret = os.Getenv("HPEUXI_CLIENT_SECRET")
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,13 +65,13 @@ func (p *hpeuxiConfigurationProvider) Schema(
 			"client_id": schema.StringAttribute{
 				Description: "The Client ID as obtained from HPE GreenLake API client credentials. " +
 					"It is recommended that this configuration is left blank and the Client ID " +
-					"is exported as the `GREENLAKE_UXI_CLIENT_ID` environment variable instead.",
+					"is exported as the `HPEUXI_CLIENT_ID` environment variable instead.",
 				Optional: true,
 			},
 			"client_secret": schema.StringAttribute{
 				Description: "The Client Secret as obtained from HPE GreenLake API client credentials. " +
 					"It is recommended that this configuration is left blank and the Client Secret " +
-					"is exported as the `GREENLAKE_UXI_CLIENT_SECRET` environment variable instead.",
+					"is exported as the `HPEUXI_CLIENT_SECRET` environment variable instead.",
 				Optional:  true,
 				Sensitive: true,
 			},
@@ -113,7 +113,7 @@ func (p *hpeuxiConfigurationProvider) Configure(
 			path.Root("client_id"),
 			"Missing Client ID",
 			"The provider cannot initialize as there is a missing or empty value for the Client ID. "+
-				"Set the client_id value in the provider configuration or use the GREENLAKE_UXI_CLIENT_ID "+
+				"Set the client_id value in the provider configuration or use the HPEUXI_CLIENT_ID "+
 				"environment variable (recommended). If either is already set, ensure the value is not empty.",
 		)
 	}
@@ -123,7 +123,7 @@ func (p *hpeuxiConfigurationProvider) Configure(
 			path.Root("client_secret"),
 			"Missing Client Secret",
 			"The provider cannot initialize as there is a missing or empty value for the Client Secret. "+
-				"Set the client_secret value in the provider configuration or use the GREENLAKE_UXI_CLIENT_SECRET "+
+				"Set the client_secret value in the provider configuration or use the HPEUXI_CLIENT_SECRET "+
 				"environment variable (recommended). If either is already set, ensure the value is not empty.",
 		)
 	}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/arubauxi/hpeuxi",
+		Address: "registry.terraform.io/aruba-uxi/hpeuxi",
 		Debug:   debug,
 	}
 

--- a/test/live/resources/agent_test.go
+++ b/test/live/resources/agent_test.go
@@ -24,7 +24,7 @@ func TestAgentResource(t *testing.T) {
 	// we provision an agent here so that we have something to delete later on
 	agentID, err := util.ProvisionAgent{
 		CustomerID:        config.CustomerID,
-		ProvisionToken:    os.Getenv("hpeuxi_PROVISION_TOKEN"),
+		ProvisionToken:    os.Getenv("HPEUXI_PROVISION_TOKEN"),
 		DeviceSerial:      config.AgentCreateSerial,
 		DeviceGatewayHost: config.DeviceGatewayHost,
 	}.Provision()

--- a/test/mocked/datasources/main_test.go
+++ b/test/mocked/datasources/main_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Setenv("UXI_HOST", util.MockDomain)
+	os.Setenv("HPEUXI_HOST_OVERRIDE", util.MockDomain)
 
 	exitCode := m.Run()
 
-	os.Unsetenv("UXI_HOST")
+	os.Unsetenv("HPEUXI_HOST_OVERRIDE")
 
 	os.Exit(exitCode)
 }

--- a/test/mocked/resources/main_test.go
+++ b/test/mocked/resources/main_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Setenv("UXI_HOST", util.MockDomain)
+	os.Setenv("HPEUXI_HOST_OVERRIDE", util.MockDomain)
 
 	exitCode := m.Run()
 
-	os.Unsetenv("UXI_HOST")
+	os.Unsetenv("HPEUXI_HOST_OVERRIDE")
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
## Description

Just update some env var naming to be consistent

## Related Issue(s)


